### PR TITLE
Fix resetState not clearing media assets

### DIFF
--- a/apps/web/src/lib/store/index.test.ts
+++ b/apps/web/src/lib/store/index.test.ts
@@ -18,4 +18,29 @@ describe('useMotifStore', () => {
     useMotifStore.getState().resetState()
     expect(useMotifStore.getState().fileInfo.fileName).toBeNull()
   })
-}) 
+
+  it('clears media assets on reset', () => {
+    const dummyMetadata = {
+      duration: 1,
+      width: 1,
+      height: 1,
+      videoCodec: null,
+      audioCodec: null,
+      frameRate: null,
+      sampleRate: null,
+      channelCount: null,
+    }
+
+    useMotifStore.getState().addMediaAsset({
+      fileName: 'asset.mp4',
+      fileHandle: null,
+      metadata: dummyMetadata,
+    })
+
+    expect(useMotifStore.getState().mediaAssets.length).toBe(1)
+
+    useMotifStore.getState().resetState()
+
+    expect(useMotifStore.getState().mediaAssets.length).toBe(0)
+  })
+})

--- a/apps/web/src/lib/store/index.ts
+++ b/apps/web/src/lib/store/index.ts
@@ -62,6 +62,7 @@ const useMotifStore = create<MotifState>((set) => ({
       videoSupported: null,
       audioSupported: null
     },
+    mediaAssets: [],
     beatMarkers: [],
     timeline: {
       clips: [],


### PR DESCRIPTION
## Summary
- clear `mediaAssets` in `resetState`
- add regression test for clearing assets

## Testing
- `npm test` *(fails: vitest not found)*