### PR TITLE
Update resetStore fields

### DIFF
--- a/apps/web/src/tests/timeline/useBeatSlices.test.tsx
+++ b/apps/web/src/tests/timeline/useBeatSlices.test.tsx
@@ -7,7 +7,7 @@ import { useTimelineStore } from '../../state/timelineStore'
 
 // Helper: reset Zustand store between tests for deterministic state
 const resetStore = () => {
-  useTimelineStore.setState({ clips: [], beats: [] })
+  useTimelineStore.setState({ clipsById: {}, durationSec: 0, beats: [] })
 }
 
 // Provide deterministic IDs so assertions are stable


### PR DESCRIPTION
## Summary
- reset timeline store fields in `useBeatSlices.test.tsx`

## Testing
- `npm test` *(fails: vitest not found)*