### PR TITLE
Fix workspace configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,1 +1,9 @@
-{}
+{
+  "name": "mediamix",
+  "private": true,
+  "workspaces": ["apps/web"],
+  "scripts": {
+    "lint": "yarn workspace web lint",
+    "test": "yarn workspace web test"
+  }
+}


### PR DESCRIPTION
## Summary
- configure root package.json as a yarn workspace so lint and test commands function correctly

## Testing
- `yarn lint` *(fails: package not in lockfile)*
- `yarn test` *(fails: package not in lockfile)*