### PR TITLE
Resolve state store merge conflicts

### DIFF
--- a/apps/web/src/state/mediaStore.ts
+++ b/apps/web/src/state/mediaStore.ts
@@ -1,0 +1,36 @@
+import { create } from 'zustand'
+
+export interface MediaAsset {
+  id: string
+  url: string
+  fileName?: string
+  duration?: number
+  waveform?: number[]
+}
+
+interface MediaState {
+  assets: Record<string, MediaAsset>
+  addAsset: (asset: MediaAsset) => void
+  updateAsset: (id: string, delta: Partial<MediaAsset>) => void
+  removeAsset: (id: string) => void
+}
+
+export const useMediaStore = create<MediaState>((set) => ({
+  assets: {},
+  addAsset: (asset) =>
+    set((state) => ({ assets: { ...state.assets, [asset.id]: asset } })),
+  updateAsset: (id, delta) =>
+    set((state) => {
+      const current = state.assets[id]
+      if (!current) return {}
+      return { assets: { ...state.assets, [id]: { ...current, ...delta } } }
+    }),
+  removeAsset: (id) =>
+    set((state) => {
+      const { [id]: _removed, ...rest } = state.assets
+      return { assets: rest }
+    }),
+}))
+
+export const selectMediaArray = (state: MediaState): MediaAsset[] =>
+  Object.values(state.assets)

--- a/apps/web/src/state/timelineStore.ts
+++ b/apps/web/src/state/timelineStore.ts
@@ -11,33 +11,73 @@ export interface Clip {
   lane: number
 }
 
+export interface Track {
+  id: string
+  type: 'video' | 'audio'
+  label: string
+}
+
 export interface TimelineState {
   /** Normalised dictionary of clips */
   clipsById: Record<string, Clip>
+  /** Track metadata */
+  tracks: Track[]
   /** Project duration in seconds (ceil of max clip end) */
   durationSec: number
+  /** Current playhead time in seconds */
+  currentTime: number
+  /** Optional in/out points in seconds */
+  inPoint: number | null
+  outPoint: number | null
   /** Replace all clips (normalised input) */
   setClips: (clips: Clip[]) => void
   addClip: (clip: Omit<Clip, 'id'>) => string
   updateClip: (id: string, delta: Partial<Omit<Clip, 'id'>>) => void
+  removeClip: (id: string, opts?: { ripple?: boolean }) => void
   /** array of beat timestamps in seconds (monotonically increasing) */
   beats: number[]
   setBeats: (beats: number[]) => void
+  setCurrentTime: (time: number) => void
+  setInPoint: (time: number | null) => void
+  setOutPoint: (time: number | null) => void
 }
 
 const toDict = (arr: Clip[]) => Object.fromEntries(arr.map((c) => [c.id, c]))
 
+const ensureTracks = (tracks: Track[], lane: number): Track[] => {
+  const next = [...tracks]
+  while (next.length <= lane) {
+    const index = next.length
+    const pair = Math.floor(index / 2) + 1
+    const type = index % 2 === 0 ? 'video' : 'audio'
+    const label = type === 'video' ? `V${pair}` : `A${pair}`
+    next.push({ id: `track-${index}`, type, label })
+  }
+  return next
+}
+
 export const useTimelineStore = create<TimelineState>((set) => ({
   clipsById: {},
+  tracks: [],
   durationSec: 0,
+  currentTime: 0,
+  inPoint: null,
+  outPoint: null,
   beats: [],
 
   // Replace entire clip collection
   setClips: (clips) =>
-    set(() => ({
-      clipsById: toDict(clips),
-      durationSec: clips.reduce((m, c) => Math.max(m, c.end), 0),
-    })),
+    set((state) => {
+      let tracks = state.tracks
+      clips.forEach((c) => {
+        tracks = ensureTracks(tracks, c.lane)
+      })
+      return {
+        clipsById: toDict(clips),
+        durationSec: clips.reduce((m, c) => Math.max(m, c.end), 0),
+        tracks,
+      }
+    }),
 
   setBeats: (beats) => set({ beats }),
 
@@ -47,7 +87,8 @@ export const useTimelineStore = create<TimelineState>((set) => ({
     set((state) => {
       const clipsById = { ...state.clipsById, [id]: newClip }
       const durationSec = Math.max(state.durationSec, newClip.end)
-      return { clipsById, durationSec }
+      const tracks = ensureTracks(state.tracks, newClip.lane)
+      return { clipsById, durationSec, tracks }
     })
     return id
   },
@@ -61,11 +102,44 @@ export const useTimelineStore = create<TimelineState>((set) => ({
       const durationSec = Math.max(
         ...Object.values(clipsById).map((c) => c.end),
       )
+      const tracks = ensureTracks(state.tracks, updated.lane)
+      return { clipsById, durationSec, tracks }
+    }),
+
+  removeClip: (id, opts) =>
+    set((state) => {
+      const clip = state.clipsById[id]
+      if (!clip) return {}
+      const { ripple } = opts ?? {}
+      const { [id]: _removed, ...rest } = state.clipsById
+      let clipsById: Record<string, Clip> = rest
+      if (ripple) {
+        const shift = clip.end - clip.start
+        clipsById = Object.fromEntries(
+          Object.entries(rest).map(([cid, c]) => {
+            if (c.lane === clip.lane && c.start > clip.start) {
+              const moved = { ...c, start: c.start - shift, end: c.end - shift }
+              return [cid, moved]
+            }
+            return [cid, c]
+          }),
+        )
+      }
+      const durationSec = Math.max(
+        0,
+        ...Object.values(clipsById).map((c) => c.end),
+      )
       return { clipsById, durationSec }
     }),
+
+  setCurrentTime: (time) => set({ currentTime: Math.max(0, time) }),
+  setInPoint: (time) => set({ inPoint: time }),
+  setOutPoint: (time) => set({ outPoint: time }),
 }))
 
 // ---- Selectors -----------------------------------------------------------
 
 export const selectClipsArray = (state: TimelineState): Clip[] =>
-  Object.values(state.clipsById) 
+  Object.values(state.clipsById)
+
+export const selectTracks = (state: TimelineState): Track[] => state.tracks

--- a/apps/web/src/tests/timeline/useBeatSlices.test.tsx
+++ b/apps/web/src/tests/timeline/useBeatSlices.test.tsx
@@ -7,7 +7,15 @@ import { useTimelineStore } from '../../state/timelineStore'
 
 // Helper: reset Zustand store between tests for deterministic state
 const resetStore = () => {
-  useTimelineStore.setState({ clipsById: {}, durationSec: 0, beats: [] })
+  useTimelineStore.setState({
+    clipsById: {},
+    tracks: [],
+    durationSec: 0,
+    currentTime: 0,
+    inPoint: null,
+    outPoint: null,
+    beats: [],
+  })
 }
 
 // Provide deterministic IDs so assertions are stable
@@ -53,8 +61,8 @@ describe('Timeline auto-slice side-effect', () => {
 
     // Assert – wait for effect to commit to store
     await waitFor(() => {
-      const { clips } = useTimelineStore.getState()
-      expect(clips.length).toBeGreaterThan(0)
+      const { clipsById } = useTimelineStore.getState()
+      expect(Object.keys(clipsById).length).toBeGreaterThan(0)
     })
   })
-}) 
+})

--- a/package.json
+++ b/package.json
@@ -1,1 +1,9 @@
-{}
+{
+  "name": "mediamix",
+  "private": true,
+  "workspaces": ["apps/web"],
+  "scripts": {
+    "lint": "yarn workspace web lint",
+    "test": "yarn workspace web test"
+  }
+}


### PR DESCRIPTION
## Summary
- merge latest main into work
- resolve conflicts in `mediaStore` and `timelineStore`
- keep ripple delete logic while adding track metadata

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*