### PR TITLE
Refine timeline track handling

### DIFF
--- a/apps/web/src/state/mediaStore.ts
+++ b/apps/web/src/state/mediaStore.ts
@@ -1,0 +1,21 @@
+import { create } from 'zustand'
+
+export interface MediaAsset {
+  id: string
+  url: string
+  duration?: number
+}
+
+interface MediaState {
+  assets: Record<string, MediaAsset>
+  addAsset: (asset: MediaAsset) => void
+}
+
+export const useMediaStore = create<MediaState>((set) => ({
+  assets: {},
+  addAsset: (asset) =>
+    set((state) => ({ assets: { ...state.assets, [asset.id]: asset } })),
+}))
+
+export const selectMediaArray = (state: MediaState): MediaAsset[] =>
+  Object.values(state.assets)

--- a/apps/web/src/state/timelineStore.ts
+++ b/apps/web/src/state/timelineStore.ts
@@ -11,33 +11,86 @@ export interface Clip {
   lane: number
 }
 
+export interface Track {
+  id: string
+  type: 'video' | 'audio'
+  label: string
+}
+
 export interface TimelineState {
   /** Normalised dictionary of clips */
   clipsById: Record<string, Clip>
+  /** Track metadata */
+  tracks: Track[]
   /** Project duration in seconds (ceil of max clip end) */
   durationSec: number
+  /** Current playhead time */
+  currentTime: number
+  /** Optional In/Out points */
+  inPoint: number | null
+  outPoint: number | null
   /** Replace all clips (normalised input) */
   setClips: (clips: Clip[]) => void
   addClip: (clip: Omit<Clip, 'id'>) => string
   updateClip: (id: string, delta: Partial<Omit<Clip, 'id'>>) => void
+  removeClip: (id: string) => void
   /** array of beat timestamps in seconds (monotonically increasing) */
   beats: number[]
   setBeats: (beats: number[]) => void
+  setCurrentTime: (t: number) => void
+  setInPoint: (t: number | null) => void
+  setOutPoint: (t: number | null) => void
 }
 
 const toDict = (arr: Clip[]) => Object.fromEntries(arr.map((c) => [c.id, c]))
 
+const ensureTracks = (tracks: Track[], lane: number): Track[] => {
+  const next = [...tracks]
+  while (next.length <= lane) {
+    const index = next.length
+    const pair = Math.floor(index / 2) + 1
+    const type = index % 2 === 0 ? 'video' : 'audio'
+    const label = type === 'video' ? `V${pair}` : `A${pair}`
+    next.push({ id: `track-${index}`, type, label })
+  }
+  return next
+}
+
+const pruneTracks = (
+  tracks: Track[],
+  clipsById: Record<string, Clip>,
+): Track[] => {
+  const maxLane = Object.values(clipsById).reduce(
+    (m, c) => Math.max(m, c.lane),
+    -1,
+  )
+  const needed = ensureTracks(tracks, maxLane)
+  return needed.slice(0, maxLane + 1)
+}
+
 export const useTimelineStore = create<TimelineState>((set) => ({
   clipsById: {},
+  tracks: [],
   durationSec: 0,
+  currentTime: 0,
+  inPoint: null,
+  outPoint: null,
   beats: [],
 
   // Replace entire clip collection
   setClips: (clips) =>
-    set(() => ({
-      clipsById: toDict(clips),
-      durationSec: clips.reduce((m, c) => Math.max(m, c.end), 0),
-    })),
+    set((state) => {
+      let tracks = state.tracks
+      clips.forEach((c) => {
+        tracks = ensureTracks(tracks, c.lane)
+      })
+      const dict = toDict(clips)
+      return {
+        clipsById: dict,
+        durationSec: clips.reduce((m, c) => Math.max(m, c.end), 0),
+        tracks: pruneTracks(tracks, dict),
+      }
+    }),
 
   setBeats: (beats) => set({ beats }),
 
@@ -47,7 +100,11 @@ export const useTimelineStore = create<TimelineState>((set) => ({
     set((state) => {
       const clipsById = { ...state.clipsById, [id]: newClip }
       const durationSec = Math.max(state.durationSec, newClip.end)
-      return { clipsById, durationSec }
+      const tracks = pruneTracks(
+        ensureTracks(state.tracks, newClip.lane),
+        clipsById,
+      )
+      return { clipsById, durationSec, tracks }
     })
     return id
   },
@@ -61,11 +118,32 @@ export const useTimelineStore = create<TimelineState>((set) => ({
       const durationSec = Math.max(
         ...Object.values(clipsById).map((c) => c.end),
       )
-      return { clipsById, durationSec }
+      const tracks = pruneTracks(
+        ensureTracks(state.tracks, updated.lane),
+        clipsById,
+      )
+      return { clipsById, durationSec, tracks }
     }),
+
+  removeClip: (id) =>
+    set((state) => {
+      const { [id]: removed, ...rest } = state.clipsById
+      const durationSec = Math.max(
+        0,
+        ...Object.values(rest).map((c) => c.end),
+      )
+      const tracks = pruneTracks(state.tracks, rest)
+      return { clipsById: rest, durationSec, tracks }
+    }),
+
+  setCurrentTime: (t) => set({ currentTime: Math.max(0, t) }),
+  setInPoint: (t) => set({ inPoint: t }),
+  setOutPoint: (t) => set({ outPoint: t }),
 }))
 
 // ---- Selectors -----------------------------------------------------------
 
 export const selectClipsArray = (state: TimelineState): Clip[] =>
-  Object.values(state.clipsById) 
+  Object.values(state.clipsById)
+
+export const selectTracks = (state: TimelineState): Track[] => state.tracks

--- a/apps/web/src/tests/timeline/useBeatSlices.test.tsx
+++ b/apps/web/src/tests/timeline/useBeatSlices.test.tsx
@@ -7,7 +7,15 @@ import { useTimelineStore } from '../../state/timelineStore'
 
 // Helper: reset Zustand store between tests for deterministic state
 const resetStore = () => {
-  useTimelineStore.setState({ clipsById: {}, durationSec: 0, beats: [] })
+  useTimelineStore.setState({
+    clipsById: {},
+    tracks: [],
+    durationSec: 0,
+    currentTime: 0,
+    inPoint: null,
+    outPoint: null,
+    beats: [],
+  })
 }
 
 // Provide deterministic IDs so assertions are stable
@@ -53,8 +61,8 @@ describe('Timeline auto-slice side-effect', () => {
 
     // Assert – wait for effect to commit to store
     await waitFor(() => {
-      const { clips } = useTimelineStore.getState()
-      expect(clips.length).toBeGreaterThan(0)
+      const { clipsById } = useTimelineStore.getState()
+      expect(Object.keys(clipsById).length).toBeGreaterThan(0)
     })
   })
-}) 
+})


### PR DESCRIPTION
## Summary
- add `pruneTracks` helper to clean unused tracks
- update `setClips`, `addClip`, `updateClip`, and `removeClip` to maintain track list

## Testing
- `npm test --silent` *(fails: `vitest` not found)*
- `npm run lint --silent` *(fails: Cannot find package '@eslint/js')*