### PR TITLE
Improve store docs and add clip selector hook

### DIFF
--- a/apps/web/src/features/timeline/components/Timeline.tsx
+++ b/apps/web/src/features/timeline/components/Timeline.tsx
@@ -7,6 +7,7 @@ import { TimeRuler } from './TimeRuler'
 import { Playhead } from './Playhead'
 import { TrackRow } from './TrackRow'
 import { useBeatSlices } from '../hooks/useBeatSlices'
+import { useClipsArray } from '../hooks/useClipsArray'
 import { useTimelineKeyboard } from '../hooks/useTimelineKeyboard'
 import { useZoomScroll } from '../hooks/useZoomScroll'
 import { ZoomSlider } from './ZoomSlider'
@@ -29,11 +30,9 @@ export const Timeline: React.FC<TimelineProps> = React.memo(({ pixelsPerSecond =
   const indicatorTimeout = React.useRef<number | null>(null)
   const scrollRef = React.useRef<HTMLDivElement>(null)
   useZoomScroll(scrollRef, zoom, setZoom, { minZoom: 20, maxZoom: 500, zoomStep: 0.002 })
-  // Cache the raw clipsById object from store to avoid recreating array each render
-  const clipsById = useTimelineStore((state) => state.clipsById)
+  // Access clips via memoized selector hook
+  const clips = useClipsArray()
   const setClips = useTimelineStore((state) => state.setClips)
-  // Memoize conversion to array for render
-  const clips = React.useMemo(() => Object.values(clipsById), [clipsById])
 
   // Show zoom change indicator briefly
   React.useEffect(() => {

--- a/apps/web/src/features/timeline/hooks/useClipsArray.ts
+++ b/apps/web/src/features/timeline/hooks/useClipsArray.ts
@@ -1,0 +1,12 @@
+import { useMemo } from 'react'
+import { useTimelineStore } from '../../../state/timelineStore'
+import type { Clip } from '../../../state/timelineStore'
+
+/**
+ * Memoized selector returning an array of clips from the
+ * timeline store's normalized dictionary.
+ */
+export const useClipsArray = (): Clip[] => {
+  const clipsById = useTimelineStore((s) => s.clipsById)
+  return useMemo(() => Object.values(clipsById), [clipsById])
+}

--- a/apps/web/src/lib/file/detectBeatsFromVideo.ts
+++ b/apps/web/src/lib/file/detectBeatsFromVideo.ts
@@ -6,13 +6,21 @@ export async function detectBeatsFromVideo(
   videoFile: File,
   onProgress?: (stage: string, value?: number) => void,
 ): Promise<number[]> {
-  // 1. Extract raw PCM audio
   onProgress?.('extractAudio', 0);
-  const { audioData, sampleRate } = await extractAudioTrack(
-    videoFile,
-    'raw',
-    (p) => onProgress?.('extractAudio', p),
-  );
+  let audioData: Int16Array;
+  let sampleRate: number;
+  try {
+    const result = await extractAudioTrack(
+      videoFile,
+      'raw',
+      (p) => onProgress?.('extractAudio', p),
+    );
+    audioData = result.audioData;
+    sampleRate = result.sampleRate;
+  } catch (err) {
+    console.error('Failed to extract audio track:', err);
+    throw err instanceof Error ? err : new Error(String(err));
+  }
   onProgress?.('extractAudio', 1);
 
   // 2. Convert to Float32 PCM

--- a/apps/web/src/state/mediaStore.ts
+++ b/apps/web/src/state/mediaStore.ts
@@ -20,12 +20,16 @@ interface MediaState {
 export const useMediaStore = create<MediaState>((set) => ({
   assets: {},
 
+  /**
+   * Add a new media asset and return its generated id.
+   */
   addAsset: (assetInput) => {
     const id = nanoid()
     set((state) => ({ assets: { ...state.assets, [id]: { id, ...assetInput } } }))
     return id
   },
 
+  /** Update existing asset metadata */
   updateAsset: (id, delta) =>
     set((state) => {
       const asset = state.assets[id]
@@ -33,6 +37,7 @@ export const useMediaStore = create<MediaState>((set) => ({
       return { assets: { ...state.assets, [id]: { ...asset, ...delta } } }
     }),
 
+  /** Remove an asset by id */
   removeAsset: (id) =>
     set((state) => {
       const { [id]: _removed, ...rest } = state.assets
@@ -40,5 +45,7 @@ export const useMediaStore = create<MediaState>((set) => ({
     }),
 }))
 
+/** Retrieve assets as an array */
 export const selectMediaArray = (state: MediaState): MediaAsset[] =>
   Object.values(state.assets)
+

--- a/apps/web/src/state/timelineStore.ts
+++ b/apps/web/src/state/timelineStore.ts
@@ -77,7 +77,10 @@ export const useTimelineStore = create<TimelineState>((set) => ({
   outPoint: null,
   beats: [],
 
-  // Replace entire clip collection
+  /**
+   * Replace the entire clip collection with a new set.
+   * Tracks and duration are updated accordingly.
+   */
   setClips: (clips) =>
     set((state) => {
       let tracks = state.tracks
@@ -92,8 +95,13 @@ export const useTimelineStore = create<TimelineState>((set) => ({
       }
     }),
 
+  /** Store beat timestamps in seconds */
   setBeats: (beats) => set({ beats }),
 
+  /**
+   * Add a new clip and return its generated id.
+   * Track metadata is expanded to fit the clip lane.
+   */
   addClip: (clipInput) => {
     const id = nanoid()
     const newClip: Clip = { id, ...clipInput }
@@ -109,6 +117,7 @@ export const useTimelineStore = create<TimelineState>((set) => ({
     return id
   },
 
+  /** Update an existing clip by id */
   updateClip: (id, delta) =>
     set((state) => {
       const existing = state.clipsById[id]
@@ -125,6 +134,10 @@ export const useTimelineStore = create<TimelineState>((set) => ({
       return { clipsById, durationSec, tracks }
     }),
 
+  /**
+   * Remove a clip. When `opts.ripple` is true, subsequent clips
+   * on the same lane shift left to fill the gap.
+   */
   removeClip: (id, opts) =>
     set((state) => {
       const clip = state.clipsById[id]
@@ -153,8 +166,11 @@ export const useTimelineStore = create<TimelineState>((set) => ({
       return { clipsById, durationSec, tracks }
     }),
 
+  /** Update the current playhead position (seconds) */
   setCurrentTime: (time) => set({ currentTime: time }),
+  /** Set the in point for playback or export */
   setInPoint: (time) => set({ inPoint: time }),
+  /** Set the out point for playback or export */
   setOutPoint: (time) => set({ outPoint: time }),
 }))
 

--- a/apps/web/src/state/transportStore.ts
+++ b/apps/web/src/state/transportStore.ts
@@ -17,8 +17,13 @@ export const useTransportStore = create<TransportState>((set) => ({
   playRate: 0,
   playheadFrame: 0,
 
+  /** Set the absolute playback rate */
   setPlayRate: (rate) => set({ playRate: rate }),
 
+  /**
+   * Increment/decrement shuttle speed by a factor of two up to ±32.
+   * If the sign changes, reset to ±1.
+   */
   stepShuttle: (direction) =>
     set((state) => {
       // if currently paused start at 1 or -1.
@@ -30,6 +35,7 @@ export const useTransportStore = create<TransportState>((set) => ({
       return { playRate: next }
     }),
 
+  /** Move the playhead by the given number of frames */
   nudgeFrames: (delta) =>
     set((state) => ({ playheadFrame: Math.max(0, state.playheadFrame + delta) })),
 })) 

--- a/apps/web/src/tests/timeline/removeClipRipple.test.tsx
+++ b/apps/web/src/tests/timeline/removeClipRipple.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { act } from '@testing-library/react'
+
+import { useTimelineStore } from '../../state/timelineStore'
+
+// Reset store after each test
+const resetStore = () => {
+  useTimelineStore.setState({
+    clipsById: {},
+    tracks: [],
+    durationSec: 0,
+    currentTime: 0,
+    inPoint: null,
+    outPoint: null,
+    beats: [],
+  })
+}
+
+describe('removeClip ripple option', () => {
+  afterEach(() => resetStore())
+
+  it('shifts subsequent clips when ripple is true', () => {
+    act(() => {
+      useTimelineStore.getState().addClip({ id: undefined as never, start: 0, end: 1, lane: 0 })
+      useTimelineStore.getState().addClip({ id: undefined as never, start: 1, end: 2, lane: 0 })
+    })
+    const ids = Object.keys(useTimelineStore.getState().clipsById)
+    const first = ids[0]
+    const second = ids[1]
+
+    act(() => {
+      useTimelineStore.getState().removeClip(first, { ripple: true })
+    })
+
+    const secondClip = useTimelineStore.getState().clipsById[second]
+    expect(secondClip.start).toBe(0)
+    expect(secondClip.end).toBe(1)
+  })
+})


### PR DESCRIPTION
## Summary
- document actions in timeline, media, and transport stores
- provide a `useClipsArray` hook for memoized clip selection
- use the new hook inside `Timeline`

## Testing
- `yarn lint` *(fails: package not in lockfile)*
- `yarn test` *(fails: package not in lockfile)*