### PR TITLE
Add GhostCuts overlay

### DIFF
--- a/apps/web/src/features/timeline/components/GhostCuts.tsx
+++ b/apps/web/src/features/timeline/components/GhostCuts.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react'
+import { useTimelineStore } from '../../../state/timelineStore'
+
+interface GhostCutsProps {
+  pixelsPerSecond: number
+  height: number | string
+}
+
+export const GhostCuts: React.FC<GhostCutsProps> = React.memo(({ pixelsPerSecond, height }) => {
+  const beats = useTimelineStore.getState().beats
+  if (!beats || beats.length === 0) return null
+
+  return (
+    <>
+      {beats.map((b) => (
+        <div
+          key={b}
+          className="absolute top-0 w-px border-r border-dashed border-accent/40 pointer-events-none"
+          style={{ height, transform: `translateX(${b * pixelsPerSecond}px)` }}
+        />
+      ))}
+    </>
+  )
+})
+
+GhostCuts.displayName = 'GhostCuts'

--- a/apps/web/src/features/timeline/components/Timeline.tsx
+++ b/apps/web/src/features/timeline/components/Timeline.tsx
@@ -6,6 +6,7 @@ import { InteractiveClip } from './InteractiveClip'
 import { TimeRuler } from './TimeRuler'
 import { Playhead } from './Playhead'
 import { TrackRow } from './TrackRow'
+import { GhostCuts } from './GhostCuts'
 import { useTransportStore } from '../../../state/transportStore'
 import { useBeatSlices } from '../hooks/useBeatSlices'
 import { useClipsArray } from '../hooks/useClipsArray'
@@ -140,6 +141,7 @@ export const Timeline: React.FC<TimelineProps> = React.memo(({ pixelsPerSecond =
           >
             <div className="relative h-full flex flex-col" style={{ width: duration * zoom }}>
               {renderedTracks}
+              <GhostCuts pixelsPerSecond={zoom} height="100%" />
               {/* Playhead overlay */}
               <Playhead positionSeconds={playheadSeconds} pixelsPerSecond={zoom} height="100%" />
             </div>


### PR DESCRIPTION
## Summary
- overlay beat lines across the track area via `GhostCuts` component
- mount `GhostCuts` in `Timeline`

## Testing
- `yarn lint` *(fails: package missing in lockfile)*
- `yarn install` *(fails: tunneling socket could not be established)*