### PR TITLE
Implement text command parsing

### DIFF
--- a/apps/web/src/ai/commandParser.ts
+++ b/apps/web/src/ai/commandParser.ts
@@ -1,0 +1,67 @@
+export interface SplitCommand {
+  type: 'split'
+  time: number
+}
+
+export interface DeleteCommand {
+  type: 'delete'
+  clipIndex: number
+  ripple: boolean
+}
+
+export type TimelineCommand = SplitCommand | DeleteCommand
+
+/**
+ * Parse a natural language command describing an edit action.
+ * Supported examples:
+ *  - "split at 5s"
+ *  - "delete clip 2"
+ *  - "ripple delete clip 1"
+ */
+export function parseCommand(input: string): TimelineCommand | null {
+  const trimmed = input.trim().toLowerCase()
+
+  const splitMatch = trimmed.match(/^split at (\d+(?:\.\d+)?)s?$/)
+  if (splitMatch) {
+    return { type: 'split', time: parseFloat(splitMatch[1]) }
+  }
+
+  const deleteMatch = trimmed.match(/^(ripple )?delete clip (\d+)$/)
+  if (deleteMatch) {
+    return {
+      type: 'delete',
+      clipIndex: parseInt(deleteMatch[2], 10),
+      ripple: !!deleteMatch[1],
+    }
+  }
+
+  return null
+}
+
+import { useTimelineStore, selectClipsArray } from '../state/timelineStore'
+
+/**
+ * Execute a textual command against the timeline store.
+ * Returns true if a command was recognized and applied.
+ */
+export function executeCommand(text: string): boolean {
+  const cmd = parseCommand(text)
+  if (!cmd) return false
+
+  const store = useTimelineStore.getState()
+  if (cmd.type === 'split') {
+    store.splitClipAt(cmd.time)
+    return true
+  }
+
+  if (cmd.type === 'delete') {
+    const clips = selectClipsArray(store).sort((a, b) => a.start - b.start)
+    const clip = clips[cmd.clipIndex - 1]
+    if (clip) {
+      store.removeClip(clip.id, { ripple: cmd.ripple })
+      return true
+    }
+  }
+
+  return false
+}

--- a/apps/web/src/tests/timeline/commandParser.test.ts
+++ b/apps/web/src/tests/timeline/commandParser.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { act } from '@testing-library/react'
+
+import { parseCommand, executeCommand } from '../../ai/commandParser'
+import { useTimelineStore } from '../../state/timelineStore'
+
+const resetStore = () => {
+  useTimelineStore.setState({
+    clipsById: {},
+    tracks: [],
+    durationSec: 0,
+    currentTime: 0,
+    inPoint: null,
+    outPoint: null,
+    beats: [],
+  })
+}
+
+describe('commandParser', () => {
+  afterEach(() => resetStore())
+
+  it('parses split and delete commands', () => {
+    expect(parseCommand('split at 5s')).toEqual({ type: 'split', time: 5 })
+    expect(parseCommand('delete clip 2')).toEqual({
+      type: 'delete',
+      clipIndex: 2,
+      ripple: false,
+    })
+    expect(parseCommand('ripple delete clip 1')).toEqual({
+      type: 'delete',
+      clipIndex: 1,
+      ripple: true,
+    })
+  })
+
+  it('executes split command', () => {
+    act(() => {
+      useTimelineStore.getState().addClip({ id: undefined as never, start: 0, end: 2, lane: 0 })
+    })
+    executeCommand('split at 1s')
+    const clips = Object.values(useTimelineStore.getState().clipsById).sort((a, b) => a.start - b.start)
+    expect(clips.length).toBe(2)
+    expect(clips[0]).toMatchObject({ start: 0, end: 1 })
+    expect(clips[1]).toMatchObject({ start: 1, end: 2 })
+  })
+
+  it('executes ripple delete clip command', () => {
+    act(() => {
+      useTimelineStore.getState().addClip({ id: undefined as never, start: 0, end: 1, lane: 0 })
+      useTimelineStore.getState().addClip({ id: undefined as never, start: 1, end: 2, lane: 0 })
+    })
+
+    executeCommand('ripple delete clip 1')
+
+    const clips = Object.values(useTimelineStore.getState().clipsById)
+    expect(clips.length).toBe(1)
+    expect(clips[0]).toMatchObject({ start: 0, end: 1 })
+  })
+})


### PR DESCRIPTION
## Summary
- add command parser for simple text commands
- attach parser to timeline store operations
- test command parsing and execution

## Testing
- `yarn lint` *(fails: package not in lockfile)*
- `yarn test` *(fails: package not in lockfile)*