### PR TITLE
Add paired video/audio import tracks

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -24,8 +24,13 @@ function App() {
       const newAssets = mediaAssets.slice(prevAssetCount.current)
       newAssets.forEach((asset, idx) => {
         // demo: use first 5 seconds or asset duration
-        const end = asset.metadata.duration != null ? Math.min(5, asset.metadata.duration) : 5
-        addClip({ start: 0, end, lane: prevAssetCount.current + idx })
+        const end =
+          asset.metadata.duration != null
+            ? Math.min(5, asset.metadata.duration)
+            : 5
+        const baseLane = (prevAssetCount.current + idx) * 2
+        addClip({ start: 0, end, lane: baseLane, assetId: asset.id })
+        addClip({ start: 0, end, lane: baseLane + 1, assetId: asset.id })
       })
       prevAssetCount.current = mediaAssets.length
     }


### PR DESCRIPTION
## Summary
- insert media assets as paired video/audio clips when imported
- ensure timeline store generates V/A track labels

## Testing
- `npm run lint` *(fails: package not in lockfile)*
- `npm test` *(fails: package not in lockfile)*