### PR TITLE
Update beat slice lane logic

### DIFF
--- a/apps/web/src/features/timeline/hooks/useBeatSlices.ts
+++ b/apps/web/src/features/timeline/hooks/useBeatSlices.ts
@@ -14,9 +14,15 @@ import { useTimelineStore } from '../../../state/timelineStore'
  */
 export const useBeatSlices = () => {
   const beats = useTimelineStore((state) => state.beats)
+  const tracks = useTimelineStore((state) => state.tracks)
 
   return useMemo(() => {
     if (!beats || beats.length < 2) return []
+
+    const videoLaneCount = Math.max(
+      1,
+      tracks.filter((t) => t.type === 'video').length,
+    )
 
     const slices = []
     for (let i = 0; i < beats.length - 1; i += 1) {
@@ -26,14 +32,19 @@ export const useBeatSlices = () => {
       // Guard against malformed beat arrays where times are not ascending
       if (end <= start) continue
 
+      const lane = (i % videoLaneCount) * 2
+
       slices.push({
-        id: typeof crypto !== 'undefined' && crypto.randomUUID ? crypto.randomUUID() : `${start}-${end}`,
+        id:
+          typeof crypto !== 'undefined' && crypto.randomUUID
+            ? crypto.randomUUID()
+            : `${start}-${end}`,
         start,
         end,
-        lane: 0,
+        lane,
       })
     }
 
     return slices
-  }, [beats])
-} 
+  }, [beats, tracks])
+}

--- a/apps/web/src/state/timelineStore.ts
+++ b/apps/web/src/state/timelineStore.ts
@@ -90,15 +90,16 @@ export const useTimelineStore = create<TimelineState>((set) => ({
    */
   setClips: (clips) =>
     set((state) => {
-      let tracks = state.tracks
-      clips.forEach((c) => {
-        tracks = ensureTracks(tracks, c.lane)
-      })
       const dict = toDict(clips)
+      const maxLane = clips.reduce((m, c) => Math.max(m, c.lane), -1)
+      const tracks = pruneTracks(
+        ensureTracks(state.tracks, maxLane),
+        dict,
+      )
       return {
         clipsById: dict,
         durationSec: clips.reduce((m, c) => Math.max(m, c.end), 0),
-        tracks: pruneTracks(tracks, dict),
+        tracks,
       }
     }),
 

--- a/apps/web/src/tests/timeline/useBeatSlices.test.tsx
+++ b/apps/web/src/tests/timeline/useBeatSlices.test.tsx
@@ -29,20 +29,25 @@ describe('useBeatSlices hook', () => {
     resetStore()
   })
 
-  it('converts beats array into adjacent clip slices', () => {
-    // Arrange – populate beats in store
-    const beats = [0, 1, 2, 3]
+  it('distributes slices round-robin across video lanes', () => {
+    // Arrange – two video tracks present
     act(() => {
-      useTimelineStore.getState().setBeats(beats)
+      useTimelineStore.setState({
+        tracks: [
+          { id: 'track-0', type: 'video', label: 'V1' },
+          { id: 'track-1', type: 'audio', label: 'A1' },
+          { id: 'track-2', type: 'video', label: 'V2' },
+          { id: 'track-3', type: 'audio', label: 'A2' },
+        ],
+      })
+      useTimelineStore.getState().setBeats([0, 1, 2, 3])
     })
 
     // Act – invoke the hook via renderHook
     const { result } = renderHook(() => useBeatSlices())
 
-    // Assert – produces beats.length - 1 slices with expected metadata
-    expect(result.current.length).toBe(beats.length - 1)
-    expect(result.current[0]).toMatchObject({ start: 0, end: 1, lane: 0 })
-    expect(result.current[2]).toMatchObject({ start: 2, end: 3 })
+    // Assert – lanes alternate between available video tracks
+    expect(result.current.map((c) => c.lane)).toEqual([0, 2, 0])
   })
 })
 


### PR DESCRIPTION
## Summary
- distribute beat slices across available video lanes
- ensure `setClips` builds any missing tracks
- update tests for multi-lane behaviour

## Testing
- `yarn lint` *(fails: package not present in lockfile)*
- `yarn test` *(fails: package not present in lockfile)*