### PR TITLE
Add auto clip creation after asset import

### DIFF
--- a/apps/web/src/tests/MediaIngest.test.tsx
+++ b/apps/web/src/tests/MediaIngest.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { render, fireEvent, waitFor, screen } from '@testing-library/react'
+import MediaIngest from '../features/import/MediaIngest'
+import { useTimelineStore } from '../state/timelineStore'
+import useMotifStore from '../lib/store'
+
+vi.mock('../lib/file/extractVideoMetadata', () => ({
+  extractVideoMetadata: vi.fn().mockResolvedValue({
+    duration: 5,
+    width: 640,
+    height: 480,
+    videoCodec: null,
+    audioCodec: null,
+    frameRate: null,
+    sampleRate: null,
+    channelCount: null,
+  }),
+}))
+
+const resetStores = () => {
+  useMotifStore.getState().resetState()
+  useTimelineStore.setState({
+    clipsById: {},
+    tracks: [],
+    durationSec: 0,
+    currentTime: 0,
+    followPlayhead: true,
+    inPoint: null,
+    outPoint: null,
+    beats: [],
+  })
+}
+
+describe('MediaIngest', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    resetStores()
+  })
+
+  it('creates timeline clips when a file is imported', async () => {
+    const file = new File(['dummy'], 'test.mp4', { type: 'video/mp4' })
+    const handle = { getFile: vi.fn().mockResolvedValue(file) }
+    type WithPicker = Window & {
+      showOpenFilePicker: () => Promise<{ getFile: () => Promise<File> }[]>
+    }
+    ;(window as unknown as WithPicker).showOpenFilePicker = vi.fn().mockResolvedValue([handle])
+
+    render(<MediaIngest />)
+    fireEvent.click(screen.getByRole('button', { name: /import media/i }))
+
+    await waitFor(() => {
+      const clips = Object.values(useTimelineStore.getState().clipsById)
+      expect(clips.length).toBe(2)
+      expect(clips[0].assetId).toBeDefined()
+      expect(clips[1].assetId).toBeDefined()
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- link timeline store to media asset import
- generate paired clips for new assets
- test MediaIngest to verify clips are created

## Testing
- `yarn lint` *(fails: many existing lint errors)*
- `yarn test` *(fails: suite errors due to import issues)*