### PR TITLE
Add waveform & thumbnail extraction

### DIFF
--- a/apps/web/src/features/import/MediaIngest.tsx
+++ b/apps/web/src/features/import/MediaIngest.tsx
@@ -2,6 +2,9 @@ import { useCallback, useState } from 'react'
 import useMotifStore from '../../lib/store'
 import { extractVideoMetadata } from '../../lib/file/extractVideoMetadata'
 import type { VideoMetadata } from '../../lib/file/extractVideoMetadata'
+import { useMediaStore } from '../../state/mediaStore'
+import { generateWaveform } from '../../lib/file/generateWaveform'
+import { captureThumbnail } from '../../lib/file/captureThumbnail'
 
 const defaultMetadata: VideoMetadata = {
   duration: null,
@@ -26,6 +29,30 @@ export default function MediaIngest() {
           const file = await handle.getFile()
           const metadata = (await extractVideoMetadata(file)) ?? defaultMetadata
           addMediaAsset({ fileName: file.name, fileHandle: handle, metadata })
+
+          const assets = useMotifStore.getState().mediaAssets
+          const assetId = assets[assets.length - 1]?.id
+          if (assetId) {
+            useMediaStore.getState().addAsset({
+              id: assetId,
+              fileName: file.name,
+              duration: metadata.duration ?? 0,
+            })
+            let waveform: number[] | undefined
+            let thumbnail: string | undefined
+            try {
+              ;[waveform, thumbnail] = await Promise.all([
+                generateWaveform(file),
+                captureThumbnail(file),
+              ])
+            } catch (err) {
+              console.warn('Media analysis failed', err)
+            }
+            useMediaStore.getState().updateAsset(assetId, {
+              waveform: waveform && waveform.length > 0 ? waveform : [0],
+              thumbnail: thumbnail ?? 'data:image/placeholder',
+            })
+          }
         } catch (err) {
           console.error('Error importing file:', err)
         }

--- a/apps/web/src/lib/file/captureThumbnail.ts
+++ b/apps/web/src/lib/file/captureThumbnail.ts
@@ -1,0 +1,31 @@
+export function captureThumbnail(videoFile: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const url = URL.createObjectURL(videoFile)
+    const video = document.createElement('video')
+    const cleanup = () => URL.revokeObjectURL(url)
+    video.muted = true
+    video.playsInline = true
+    video.src = url
+    video.addEventListener('loadeddata', () => {
+      const canvas = document.createElement('canvas')
+      const w = video.videoWidth || 160
+      const h = video.videoHeight || 90
+      canvas.width = w
+      canvas.height = h
+      const ctx = canvas.getContext('2d')
+      if (!ctx) {
+        cleanup()
+        reject(new Error('Canvas 2D not available'))
+        return
+      }
+      ctx.drawImage(video, 0, 0, w, h)
+      const data = canvas.toDataURL('image/png')
+      cleanup()
+      resolve(data)
+    })
+    video.addEventListener('error', () => {
+      cleanup()
+      reject(new Error('Video load error'))
+    })
+  })
+}

--- a/apps/web/src/lib/file/generateWaveform.ts
+++ b/apps/web/src/lib/file/generateWaveform.ts
@@ -1,0 +1,42 @@
+import { extractAudioTrack } from './extractAudioTrack'
+import { int16ToFloat32 } from '../../utils/pcm'
+
+export async function generateWaveform(
+  videoFile: File,
+  peakCount = 200,
+): Promise<number[]> {
+  const { audioData, sampleRate } = await extractAudioTrack(
+    videoFile,
+    'raw',
+  )
+  let samples = int16ToFloat32(audioData)
+  if (typeof OfflineAudioContext !== 'undefined') {
+    try {
+      const ctx = new OfflineAudioContext(1, samples.length, sampleRate)
+      const buffer = ctx.createBuffer(1, samples.length, sampleRate)
+      buffer.getChannelData(0).set(samples)
+      const src = ctx.createBufferSource()
+      src.buffer = buffer
+      src.connect(ctx.destination)
+      src.start()
+      const rendered = await ctx.startRendering()
+      samples = rendered.getChannelData(0)
+    } catch (err) {
+      console.warn('OfflineAudioContext processing failed', err)
+    }
+  }
+  const len = peakCount
+  const step = samples.length / len
+  const peaks = new Array<number>(len)
+  for (let i = 0; i < len; i += 1) {
+    const start = Math.floor(i * step)
+    const end = Math.floor((i + 1) * step)
+    let max = 0
+    for (let j = start; j < end && j < samples.length; j += 1) {
+      const v = Math.abs(samples[j])
+      if (v > max) max = v
+    }
+    peaks[i] = max
+  }
+  return peaks
+}

--- a/apps/web/src/lib/store/index.ts
+++ b/apps/web/src/lib/store/index.ts
@@ -2,7 +2,7 @@ import { create } from 'zustand'
 import type { MotifState, FileInfo, ClipSegment, BeatMarker, MediaAsset } from './types'
 
 import { generateId } from '../../utils/id'
-import { useTimelineStore } from '../state/timelineStore'
+import { useTimelineStore } from '../../state/timelineStore'
 
 // Create the store
 const useMotifStore = create<MotifState>((set) => ({

--- a/apps/web/src/state/mediaStore.ts
+++ b/apps/web/src/state/mediaStore.ts
@@ -18,7 +18,7 @@ export interface MediaAsset {
 
 interface MediaState {
   assets: Record<string, MediaAsset>
-  addAsset: (asset: Omit<MediaAsset, 'id'>) => string
+  addAsset: (asset: Omit<MediaAsset, 'id'> & { id?: string }) => string
   updateAsset: (id: string, delta: Partial<Omit<MediaAsset, 'id'>>) => void
   removeAsset: (id: string) => void
 }
@@ -30,8 +30,9 @@ export const useMediaStore = create<MediaState>((set) => ({
    * Add a new media asset and return its generated id.
    */
   addAsset: (assetInput) => {
-    const id = generateId()
-    set((state) => ({ assets: { ...state.assets, [id]: { id, ...assetInput } } }))
+    const { id: providedId, ...rest } = assetInput as any
+    const id = providedId ?? generateId()
+    set((state) => ({ assets: { ...state.assets, [id]: { id, ...rest } } }))
     return id
   },
 

--- a/apps/web/src/tests/MediaIngest.test.tsx
+++ b/apps/web/src/tests/MediaIngest.test.tsx
@@ -1,8 +1,11 @@
 import { describe, it, expect, afterEach, vi } from 'vitest'
+import React from 'react'
 import { render, fireEvent, waitFor, screen } from '@testing-library/react'
 import MediaIngest from '../features/import/MediaIngest'
 import { useTimelineStore } from '../state/timelineStore'
 import useMotifStore from '../lib/store'
+import { useMediaStore } from '../state/mediaStore'
+import { Clip } from '../features/timeline/components/Clip'
 
 vi.mock('../lib/file/extractVideoMetadata', () => ({
   extractVideoMetadata: vi.fn().mockResolvedValue({
@@ -15,6 +18,12 @@ vi.mock('../lib/file/extractVideoMetadata', () => ({
     sampleRate: null,
     channelCount: null,
   }),
+}))
+vi.mock('../lib/file/generateWaveform', () => ({
+  generateWaveform: vi.fn().mockResolvedValue([0.1, 0.2]),
+}))
+vi.mock('../lib/file/captureThumbnail', () => ({
+  captureThumbnail: vi.fn().mockResolvedValue('data:image/png;base64,test'),
 }))
 
 const resetStores = () => {
@@ -29,6 +38,7 @@ const resetStores = () => {
     outPoint: null,
     beats: [],
   })
+  useMediaStore.setState({ assets: {} })
 }
 
 describe('MediaIngest', () => {
@@ -53,6 +63,23 @@ describe('MediaIngest', () => {
       expect(clips.length).toBe(2)
       expect(clips[0].assetId).toBeDefined()
       expect(clips[1].assetId).toBeDefined()
+      const assets = useMediaStore.getState().assets
+      const asset = assets[clips[0].assetId as string]
+      expect(asset.waveform?.length).toBeGreaterThan(0)
+      expect(asset.thumbnail).toContain('data:image')
     })
+
+    const clips = Object.values(useTimelineStore.getState().clipsById)
+    const videoClip = clips.find((c) => c.lane % 2 === 0)!
+    const audioClip = clips.find((c) => c.lane % 2 === 1)!
+    const { container: vCont } = render(
+      <Clip clip={videoClip} pixelsPerSecond={100} type="video" />,
+    )
+    const videoDiv = vCont.querySelector('div') as HTMLDivElement
+    expect(videoDiv.style.backgroundImage).toContain('data:image')
+    const { container: aCont } = render(
+      <Clip clip={audioClip} pixelsPerSecond={100} type="audio" />,
+    )
+    expect(aCont.querySelector('canvas')).not.toBeNull()
   })
 })

--- a/apps/web/vitest.setup.ts
+++ b/apps/web/vitest.setup.ts
@@ -113,6 +113,15 @@ vi.mock('../src/lib/file/extractAudioTrack', () => {
   };
 });
 
+// Mock waveform and thumbnail generation to keep tests fast
+vi.mock('../src/lib/file/generateWaveform', () => ({
+  generateWaveform: vi.fn().mockResolvedValue([0.1, 0.2, 0.3]),
+}))
+
+vi.mock('../src/lib/file/captureThumbnail', () => ({
+  captureThumbnail: vi.fn().mockResolvedValue('data:image/png;base64,mock'),
+}))
+
 // Mock detectBeatsFromVideo with a proper implementation
 vi.mock('../src/lib/file/detectBeatsFromVideo', () => {
   return {


### PR DESCRIPTION
## Summary
- compute waveforms and thumbnails on import
- store waveform data and thumbnail URLs in `mediaStore`
- render thumbnails and waveforms in `Clip`
- add unit test coverage
- fix asset import path in motif store and provide fallback waveforms

## Testing
- `yarn lint` *(fails: many Prettier errors)*
- `yarn workspace web test src/tests/MediaIngest.test.tsx --run`