### PR TITLE
Implement in/out overlay on TimeRuler

### DIFF
--- a/apps/web/src/features/timeline/components/TimeRuler.tsx
+++ b/apps/web/src/features/timeline/components/TimeRuler.tsx
@@ -80,6 +80,10 @@ export const TimeRuler: React.FC<TimeRulerProps> = ({
 }) => {
   /* --------------- state & refs --------------------------------------- */
   const beats = useTimelineStore((s: TimelineState) => s.beats)
+  const [inPoint, outPoint] = useTimelineStore((s: TimelineState) => [
+    s.inPoint,
+    s.outPoint,
+  ])
   const scrollLeft = useScrollLeft(scrollContainerRef)
 
   const canvasRef = React.useRef<HTMLCanvasElement>(null)
@@ -90,6 +94,15 @@ export const TimeRuler: React.FC<TimeRulerProps> = ({
     x: number
     time: number
   }>({ visible: false, x: 0, time: 0 })
+
+  const showRange =
+    inPoint !== null && outPoint !== null && outPoint > inPoint
+  const rangeStyle = React.useMemo(() => {
+    if (!showRange) return undefined
+    const left = inPoint! * pixelsPerSecond - scrollLeft
+    const width = (outPoint! - inPoint!) * pixelsPerSecond
+    return { left: `${left}px`, width: `${width}px` }
+  }, [showRange, inPoint, outPoint, pixelsPerSecond, scrollLeft])
 
   /* --------------- drawing logic -------------------------------------- */
   const draw = React.useCallback(() => {
@@ -201,6 +214,13 @@ export const TimeRuler: React.FC<TimeRulerProps> = ({
       <div style={{ width: duration * pixelsPerSecond }}>
         <canvas ref={canvasRef} className="block h-full w-full" />
       </div>
+      {showRange && (
+        <div
+          data-testid="inout-overlay"
+          className="absolute top-0 bottom-0 bg-accent/20 pointer-events-none"
+          style={rangeStyle}
+        />
+      )}
 
       {/* hover timecode tooltip */}
       {tooltip.visible && (

--- a/apps/web/src/tests/timeline/timeRulerOverlay.test.tsx
+++ b/apps/web/src/tests/timeline/timeRulerOverlay.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, act } from '@testing-library/react'
+import React from 'react'
+
+import { TimeRuler } from '../../features/timeline/components/TimeRuler'
+import { useTimelineStore } from '../../state/timelineStore'
+
+const resetStore = () => {
+  useTimelineStore.setState({
+    clipsById: {},
+    tracks: [],
+    durationSec: 0,
+    currentTime: 0,
+    followPlayhead: true,
+    inPoint: null,
+    outPoint: null,
+    beats: [],
+  })
+}
+
+describe('TimeRuler in/out overlay', () => {
+  afterEach(() => resetStore())
+
+  it('renders overlay between in and out points', () => {
+    act(() => {
+      useTimelineStore.getState().setInPoint(1)
+      useTimelineStore.getState().setOutPoint(3)
+    })
+
+    const scrollRef = React.createRef<HTMLDivElement>()
+    const { getByTestId } = render(
+      <div>
+        <div ref={scrollRef} />
+        <TimeRuler scrollContainerRef={scrollRef} pixelsPerSecond={100} duration={10} />
+      </div>,
+    )
+
+    const overlay = getByTestId('inout-overlay') as HTMLElement
+    expect(overlay.style.left).toBe('100px')
+    expect(overlay.style.width).toBe('200px')
+  })
+})


### PR DESCRIPTION
## Summary
- draw selection overlay on TimeRuler when in/out points are set
- expose in/out points from store to TimeRuler
- test overlay placement

## Testing
- `yarn lint` *(fails: many prettier errors)*
- `yarn test` *(fails: several unit tests fail)*