### PR TITLE
Add click-to-set time on TimeRuler

### DIFF
--- a/apps/web/src/features/timeline/components/TimeRuler.tsx
+++ b/apps/web/src/features/timeline/components/TimeRuler.tsx
@@ -187,12 +187,24 @@ export const TimeRuler: React.FC<TimeRulerProps> = ({
     [pixelsPerSecond, scrollLeft],
   )
 
+  const onClick = React.useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      const rect = e.currentTarget.getBoundingClientRect()
+      const localX = e.clientX - rect.left
+      const absoluteX = localX + scrollLeft
+      const time = absoluteX / pixelsPerSecond
+      useTimelineStore.getState().setCurrentTime(time)
+    },
+    [pixelsPerSecond, scrollLeft],
+  )
+
   /* --------------- render --------------------------------------------- */
   return (
     <div
       ref={containerRef}
       className="relative h-6 select-none border-b border-white/10 bg-panel-bg"
       onMouseMove={onMouseMove}
+      onClick={onClick}
       onMouseLeave={() =>
         setTooltip((prev) => ({ ...prev, visible: false }))
       }

--- a/apps/web/src/tests/timeline/timeRulerClick.test.tsx
+++ b/apps/web/src/tests/timeline/timeRulerClick.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, afterEach, expect } from 'vitest'
+import { render, fireEvent, act } from '@testing-library/react'
+import React from 'react'
+import { TimeRuler } from '../../features/timeline/components/TimeRuler'
+import { useTimelineStore } from '../../state/timelineStore'
+
+const resetStore = () => {
+  useTimelineStore.setState({
+    clipsById: {},
+    tracks: [],
+    durationSec: 0,
+    currentTime: 0,
+    followPlayhead: true,
+    inPoint: null,
+    outPoint: null,
+    beats: [],
+  })
+}
+
+describe('TimeRuler click', () => {
+  afterEach(() => {
+    resetStore()
+  })
+
+  it('updates currentTime when clicked', () => {
+    const scrollRef = React.createRef<HTMLDivElement>()
+    const { container } = render(
+      <>
+        <div ref={scrollRef} />
+        <TimeRuler scrollContainerRef={scrollRef} pixelsPerSecond={100} duration={10} />
+      </>,
+    )
+
+    const rulerDiv = container.querySelector('canvas')!.parentElement!.parentElement as HTMLDivElement
+
+    Object.defineProperty(rulerDiv, 'getBoundingClientRect', {
+      value: () => ({ left: 0, top: 0, width: 200, height: 6, right: 200, bottom: 6 }),
+    })
+
+    act(() => {
+      fireEvent.click(rulerDiv, { clientX: 150 })
+    })
+
+    expect(useTimelineStore.getState().currentTime).toBeCloseTo(1.5)
+  })
+})


### PR DESCRIPTION
## Summary
- allow TimeRuler to update the playhead when clicked
- test that clicking the ruler changes currentTime

## Testing
- `yarn lint` *(fails: many lint errors)*
- `yarn test` *(fails: Video import tests fail and canvas not implemented)*