### PR TITLE
Add JSDoc to timeline modules

### DIFF
--- a/apps/web/src/features/timeline/components/Clip.tsx
+++ b/apps/web/src/features/timeline/components/Clip.tsx
@@ -3,18 +3,22 @@ import * as React from 'react'
 import type { Clip as ClipType } from '../../../state/timelineStore'
 import { useMediaStore } from '../../../state/mediaStore'
 
+/** Props for {@link Clip}. */
 interface ClipProps {
+  /** Clip data describing timing and lane */
   clip: ClipType
+  /** Zoom level in pixels per second for sizing */
   pixelsPerSecond: number
   /** Track type for styling */
   type: 'video' | 'audio'
 }
 
-/*
- * Memoized for perf – parent handles re-renders when clip array changes.
- * Inline styles are used here only for dynamic positioning/size which cannot
- * be expressed via Tailwind utility classes at build-time due to their
- * runtime nature.
+/**
+ * Visual representation of a timeline clip.
+ *
+ * Memoized for performance – parent components re-render when the clip array
+ * changes. Uses inline styles for positioning/size which depend on runtime
+ * values (start, end, zoom level).
  */
 export const Clip = React.memo(
   React.forwardRef<HTMLDivElement, ClipProps>(({ clip, pixelsPerSecond, type }, ref) => {

--- a/apps/web/src/features/timeline/components/InteractiveClip.tsx
+++ b/apps/web/src/features/timeline/components/InteractiveClip.tsx
@@ -8,13 +8,25 @@ import { useTimelineStore } from '../../../state/timelineStore'
 import { useClipsArray } from '../hooks/useClipsArray'
 import { Clip } from './Clip'
 
+/** Props for {@link InteractiveClip}. */
 interface InteractiveClipProps {
+  /** Clip data to render and manipulate */
   clip: ClipType
+  /** Current zoom level in pixels per second */
   pixelsPerSecond: number
   /** Track type to style the clip – video vs audio */
   type: 'video' | 'audio'
 }
 
+/**
+ * Wrapper around {@link Clip} that adds drag and resize behavior via
+ * `react-moveable`.
+ *
+ * @param clip clip data being edited
+ * @param pixelsPerSecond zoom level for positioning
+ * @param type media type to style the clip
+ * @returns element rendering the interactive clip
+ */
 export const InteractiveClip: React.FC<InteractiveClipProps> = React.memo(({ clip, pixelsPerSecond, type }) => {
   const updateClip = useTimelineStore((s) => s.updateClip)
   const beats = useTimelineStore((s) => s.beats)

--- a/apps/web/src/features/timeline/components/Playhead.tsx
+++ b/apps/web/src/features/timeline/components/Playhead.tsx
@@ -1,8 +1,10 @@
 import * as React from 'react'
 
+/** Props for the {@link Playhead} component. */
 interface PlayheadProps {
-  /** playhead position in seconds */
+  /** Playhead position in seconds */
   positionSeconds: number
+  /** Pixels per second used to calculate x position */
   pixelsPerSecond: number
   /** Height of the timeline area to span */
   height: number | string
@@ -11,8 +13,14 @@ interface PlayheadProps {
 }
 
 /**
- * Playhead – simple vertical line representing the current playhead location.
- * For MVP it is purely presentational driven by parent state.
+ * Vertical line showing the current playhead location.
+ * Purely presentational and controlled by parent state.
+ *
+ * @param positionSeconds playhead position in seconds
+ * @param pixelsPerSecond zoom scale for converting time to pixels
+ * @param height height of the line
+ * @param offsetX horizontal scroll offset when overlaid
+ * @returns visual playhead line element
  */
 export const Playhead: React.FC<PlayheadProps> = React.memo(({ positionSeconds, pixelsPerSecond, height, offsetX = 0 }) => {
   const x = positionSeconds * pixelsPerSecond - offsetX

--- a/apps/web/src/features/timeline/components/TimeRuler.tsx
+++ b/apps/web/src/features/timeline/components/TimeRuler.tsx
@@ -6,12 +6,13 @@ import type { TimelineState } from '../../../state/timelineStore'
 /* Types                                                                      */
 /* -------------------------------------------------------------------------- */
 
+/** Props for {@link TimeRuler}. */
 interface TimeRulerProps {
-  /** Scroll container ref to stay in-sync with timeline scrolling      */
+  /** Scroll container ref to stay in-sync with timeline scrolling */
   scrollContainerRef: React.RefObject<HTMLDivElement>
-  /** How many horizontal pixels represent one second                   */
+  /** How many horizontal pixels represent one second */
   pixelsPerSecond: number
-  /** Total timeline duration in seconds (defines full ruler width)     */
+  /** Total timeline duration in seconds (defines full ruler width) */
   duration: number
 }
 
@@ -20,8 +21,11 @@ interface TimeRulerProps {
 /* -------------------------------------------------------------------------- */
 
 /**
- * Keeps `scrollLeft` state in sync with a scroll container
- * without triggering excessive re-renders (throttled to rAF).
+ * Keeps `scrollLeft` state in sync with a scroll container without
+ * triggering excessive re-renders (throttled with `requestAnimationFrame`).
+ *
+ * @param ref reference to the scrollable element
+ * @returns current scrollLeft value
  */
 function useScrollLeft(ref: React.RefObject<HTMLDivElement>) {
   const [scrollLeft, setScrollLeft] = React.useState(0)
@@ -56,7 +60,12 @@ function useScrollLeft(ref: React.RefObject<HTMLDivElement>) {
 /* Helpers                                                                    */
 /* -------------------------------------------------------------------------- */
 
-/** Format seconds → HH:MM:SS.FF (30 fps)                                    */
+/**
+ * Convert seconds to a HH:MM:SS.FF timecode string at 30fps.
+ *
+ * @param seconds time in seconds
+ * @returns formatted timecode
+ */
 const formatTimecode = (seconds: number) => {
   const fps = 30
   const totalFrames = Math.round(seconds * fps)
@@ -73,6 +82,14 @@ const formatTimecode = (seconds: number) => {
 /* Component                                                                  */
 /* -------------------------------------------------------------------------- */
 
+/**
+ * Canvas-based ruler displaying time ticks and optional beat markers.
+ *
+ * @param scrollContainerRef reference to the synced scroll container
+ * @param pixelsPerSecond zoom scale for drawing ticks
+ * @param duration total timeline duration in seconds
+ * @returns React element with a canvas ruler
+ */
 export const TimeRuler: React.FC<TimeRulerProps> = ({
   scrollContainerRef,
   pixelsPerSecond,

--- a/apps/web/src/features/timeline/components/Timeline.tsx
+++ b/apps/web/src/features/timeline/components/Timeline.tsx
@@ -16,15 +16,20 @@ import { useZoomScroll } from '../hooks/useZoomScroll'
 import { ZoomSlider } from './ZoomSlider'
 import { Button } from '../../../components/ui/Button'
 
+/** Props for the {@link Timeline} component. */
 interface TimelineProps {
-  /** zoom factor – how many horizontal pixels represent one second */
+  /**
+   * Initial zoom level – number of horizontal pixels that represent one second
+   * of timeline time.
+   */
   pixelsPerSecond?: number
 }
 
 /**
- * Timeline container that renders clip segments horizontally.
- * The component itself has minimal logic – behaviour (drag/resize, playhead) is
- * added in later subtasks.
+ * Main timeline container displaying tracks, clips and the playhead.
+ *
+ * @param pixelsPerSecond initial zoom level in pixels per second
+ * @returns React element containing the entire timeline UI
  */
 export const Timeline: React.FC<TimelineProps> = React.memo(({ pixelsPerSecond = 100 }) => {
   // Zoom and scroll: initialize state and scroll container ref

--- a/apps/web/src/features/timeline/components/TrackRow.tsx
+++ b/apps/web/src/features/timeline/components/TrackRow.tsx
@@ -2,13 +2,26 @@ import * as React from 'react'
 import type { Clip as ClipType } from '../../../state/timelineStore'
 import { InteractiveClip } from './InteractiveClip'
 
+/** Props for {@link TrackRow}. */
 interface TrackRowProps {
+  /** Zero-based lane index this row represents */
   laneIndex: number
+  /** Clips belonging to this track */
   clips: ClipType[]
+  /** Current zoom level in pixels per second */
   pixelsPerSecond: number
+  /** Track media type to control styling */
   type: 'video' | 'audio'
 }
 
+/**
+ * Render a single track lane and its clips.
+ *
+ * @param laneIndex index of the track lane
+ * @param clips clips to display
+ * @param pixelsPerSecond zoom level used for clip sizing
+ * @param type video or audio row styling
+ */
 export const TrackRow: React.FC<TrackRowProps> = React.memo(({ laneIndex, clips, pixelsPerSecond, type }) => {
   const height = type === 'video' ? 48 : 32
 

--- a/apps/web/src/features/timeline/hooks/useZoomScroll.ts
+++ b/apps/web/src/features/timeline/hooks/useZoomScroll.ts
@@ -1,17 +1,22 @@
 import { useEffect, useRef } from 'react'
 
+/** Optional configuration for {@link useZoomScroll}. */
 interface UseZoomScrollOptions {
+  /** Minimum allowed zoom level */
   minZoom?: number
+  /** Maximum allowed zoom level */
   maxZoom?: number
+  /** Increment applied per wheel delta */
   zoomStep?: number
 }
 
 /**
- * Hook to enable smooth zooming (Ctrl+Wheel, pinch) and click-and-drag scrolling with inertia.
- * @param containerRef Ref to the scrollable container element
- * @param zoom Current zoom level (pixels per second)
- * @param setZoom Function to update the zoom level
- * @param options minZoom, maxZoom, and zoomStep configuration
+ * Enable smooth zooming (Ctrl+wheel or pinch) and drag panning with inertia.
+ *
+ * @param containerRef ref to the scrollable container element
+ * @param zoom current zoom level in pixels per second
+ * @param setZoom callback to update the zoom level
+ * @param options optional configuration
  */
 export function useZoomScroll(
   containerRef: React.RefObject<HTMLElement>,

--- a/apps/web/src/state/playbackTicker.ts
+++ b/apps/web/src/state/playbackTicker.ts
@@ -2,9 +2,10 @@ import { useEffect, useRef } from 'react'
 import { useTransportStore } from './transportStore'
 
 /**
- * Hook that advances the playhead while playback is active.
- * It runs a requestAnimationFrame loop throttled to ~30fps
- * and nudges the playhead by the current play rate each tick.
+ * Advance the playhead while playback is running.
+ *
+ * Runs a `requestAnimationFrame` loop throttled to roughly 30 fps and
+ * calls `nudgeFrames` each tick according to the current play rate.
  */
 export function usePlaybackTicker() {
   const playRate = useTransportStore((s) => s.playRate)


### PR DESCRIPTION
## Summary
- document timeline components and hooks using JSDoc
- clarify playback ticker hook

## Testing
- `yarn lint` *(fails: many existing lint errors)*
- `yarn test` *(fails: 1 test file failed)*