### PR TITLE
Add click-to-set time on TimeRuler

### DIFF
--- a/apps/web/src/features/timeline/components/TimeRuler.tsx
+++ b/apps/web/src/features/timeline/components/TimeRuler.tsx
@@ -187,12 +187,24 @@ export const TimeRuler: React.FC<TimeRulerProps> = ({
     [pixelsPerSecond, scrollLeft],
   )
 
+  const onClick = React.useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      const rect = e.currentTarget.getBoundingClientRect()
+      const localX = e.clientX - rect.left
+      const absoluteX = localX + scrollLeft
+      const time = absoluteX / pixelsPerSecond
+      useTimelineStore.getState().setCurrentTime(time)
+    },
+    [pixelsPerSecond, scrollLeft],
+  )
+
   /* --------------- render --------------------------------------------- */
   return (
     <div
       ref={containerRef}
       className="relative h-6 select-none border-b border-white/10 bg-panel-bg"
       onMouseMove={onMouseMove}
+      onClick={onClick}
       onMouseLeave={() =>
         setTooltip((prev) => ({ ...prev, visible: false }))
       }

--- a/apps/web/src/tests/file-import/video-import.integration.test.tsx
+++ b/apps/web/src/tests/file-import/video-import.integration.test.tsx
@@ -44,7 +44,21 @@ const initialFileInfo: FileInfo = {
 // Global mock store that components can update
 // Typed mockStoreData using a subset of MotifState relevant to these tests.
 // It's important that the initial shape includes all keys that will be accessed or set.
-let mockStoreData: Pick<MotifState, 'fileInfo' | 'isFileLoading' | 'fileError' | 'beatMarkers' | 'isBeatDetectionRunning' | 'beatDetectionError' | 'beatDetectionProgress' | 'beatDetectionStage' | 'timeline' | 'isExporting' | 'exportProgress' | 'exportError'> & { currentFile: FileInfo | null } = {
+let mockStoreData: Pick<
+  MotifState,
+  | 'fileInfo'
+  | 'isFileLoading'
+  | 'fileError'
+  | 'beatMarkers'
+  | 'isBeatDetectionRunning'
+  | 'beatDetectionError'
+  | 'beatDetectionProgress'
+  | 'beatDetectionStage'
+  | 'timeline'
+  | 'isExporting'
+  | 'exportProgress'
+  | 'exportError'
+> & { currentFile: FileInfo | null; mediaAssets: any[] } = {
   fileInfo: { ...initialFileInfo }, // Initialize with the full FileInfo structure
   isFileLoading: false,
   fileError: null,
@@ -57,6 +71,7 @@ let mockStoreData: Pick<MotifState, 'fileInfo' | 'isFileLoading' | 'fileError' |
   isExporting: false,
   exportProgress: 0,
   exportError: null,
+  mediaAssets: [],
   currentFile: null,
 };
 
@@ -97,7 +112,13 @@ const mockSetBeatDetectionStage = vi.fn((stage) => {
   mockStoreData = { ...mockStoreData, beatDetectionStage: stage };
   // vi.advanceTimersByTime(0); // Temporarily commented out
 });
-const mockAddMediaAsset = vi.fn();
+const mockAddMediaAsset = vi.fn((asset) => {
+  const id = `asset-${mockStoreData.mediaAssets.length + 1}`;
+  mockStoreData.mediaAssets = [
+    ...mockStoreData.mediaAssets,
+    { id, ...asset },
+  ];
+});
 const mockResetStore = vi.fn(() => {
   mockStoreData = {
     fileInfo: { ...initialFileInfo },
@@ -112,6 +133,7 @@ const mockResetStore = vi.fn(() => {
     isExporting: false,
     exportProgress: 0,
     exportError: null,
+    mediaAssets: [],
     currentFile: null,
   };
   // vi.advanceTimersByTime(0); // Temporarily commented out
@@ -178,6 +200,8 @@ const mockActions = {
   addMediaAsset: mockAddMediaAsset,
   resetStore: mockResetStore,
 };
+
+mockUseMotifStore.getState = () => ({ ...mockStoreData, ...mockActions });
 
 
 vi.mock('../../lib/store', () => ({
@@ -297,6 +321,7 @@ describe('Video import flow (integration)', () => {
       isExporting: false,
       exportProgress: 0,
       exportError: null,
+      mediaAssets: [],
       currentFile: null,
     };
     // vi.useFakeTimers(); // Temporarily commented out

--- a/apps/web/src/tests/timeline/timeRulerClick.test.tsx
+++ b/apps/web/src/tests/timeline/timeRulerClick.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, afterEach, expect } from 'vitest'
+import { render, fireEvent, act } from '@testing-library/react'
+import React from 'react'
+import { TimeRuler } from '../../features/timeline/components/TimeRuler'
+import { useTimelineStore } from '../../state/timelineStore'
+
+const resetStore = () => {
+  useTimelineStore.setState({
+    clipsById: {},
+    tracks: [],
+    durationSec: 0,
+    currentTime: 0,
+    followPlayhead: true,
+    inPoint: null,
+    outPoint: null,
+    beats: [],
+  })
+}
+
+describe('TimeRuler click', () => {
+  afterEach(() => {
+    resetStore()
+  })
+
+  it('updates currentTime when clicked', () => {
+    const scrollRef = React.createRef<HTMLDivElement>()
+    const { container } = render(
+      <>
+        <div ref={scrollRef} />
+        <TimeRuler scrollContainerRef={scrollRef} pixelsPerSecond={100} duration={10} />
+      </>,
+    )
+
+    const rulerDiv = container.querySelector('canvas')!.parentElement!.parentElement as HTMLDivElement
+
+    Object.defineProperty(rulerDiv, 'getBoundingClientRect', {
+      value: () => ({ left: 0, top: 0, width: 200, height: 6, right: 200, bottom: 6 }),
+    })
+
+    act(() => {
+      fireEvent.click(rulerDiv, { clientX: 150 })
+    })
+
+    expect(useTimelineStore.getState().currentTime).toBeCloseTo(1.5)
+  })
+})

--- a/apps/web/vitest.setup.ts
+++ b/apps/web/vitest.setup.ts
@@ -91,6 +91,34 @@ if (typeof window !== 'undefined') {
   if (!window.URL.revokeObjectURL) {
     window.URL.revokeObjectURL = vi.fn()
   }
+  if (!HTMLCanvasElement.prototype.getContext) {
+    HTMLCanvasElement.prototype.getContext = vi.fn(() => ({
+      fillRect: vi.fn(),
+      clearRect: vi.fn(),
+      getImageData: vi.fn(() => ({ data: [] })),
+      putImageData: vi.fn(),
+      createImageData: vi.fn(() => []),
+      setTransform: vi.fn(),
+      drawImage: vi.fn(),
+      save: vi.fn(),
+      fillText: vi.fn(),
+      restore: vi.fn(),
+      beginPath: vi.fn(),
+      moveTo: vi.fn(),
+      lineTo: vi.fn(),
+      closePath: vi.fn(),
+      stroke: vi.fn(),
+      translate: vi.fn(),
+      scale: vi.fn(),
+      rotate: vi.fn(),
+      arc: vi.fn(),
+      fill: vi.fn(),
+      measureText: vi.fn(() => ({ width: 0 })),
+      transform: vi.fn(),
+      rect: vi.fn(),
+      clip: vi.fn(),
+    }))
+  }
   if (!('indexedDB' in window)) {
     class FakeDB {
       name: string


### PR DESCRIPTION
## Summary
- allow TimeRuler to update the playhead when clicked
- test that clicking the ruler changes currentTime
- extend video import integration test store mock with `mediaAssets` and a working `getState`
- polyfill canvas context in test setup

## Testing
- `yarn lint` *(fails: many lint errors)*
- `yarn test` *(fails: Video import integration tests fail)*
