### PR TITLE
Implement media analysis caching

### DIFF
--- a/apps/web/src/lib/cache.ts
+++ b/apps/web/src/lib/cache.ts
@@ -10,8 +10,47 @@ export const initCache = async (): Promise<IDBDatabase | null> => {
       if (!names.includes('chunks')) {
         db.createObjectStore('chunks')
       }
+      if (!names.includes('analysis')) {
+        db.createObjectStore('analysis')
+      }
     }
     request.onerror = () => reject(request.error)
     request.onsuccess = () => resolve(request.result)
+  })
+}
+
+let dbPromise: Promise<IDBDatabase | null> | null = null
+
+const getDb = () => {
+  if (!dbPromise) {
+    dbPromise = initCache()
+  }
+  return dbPromise
+}
+
+export async function getCachedAnalysis<T>(key: string): Promise<T | null> {
+  const db = await getDb()
+  if (!db) return null
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction('analysis', 'readonly')
+    const store = tx.objectStore('analysis')
+    const req = store.get(key)
+    req.onsuccess = () => resolve(req.result ?? null)
+    req.onerror = () => reject(req.error)
+  })
+}
+
+export async function setCachedAnalysis<T>(
+  key: string,
+  value: T,
+): Promise<void> {
+  const db = await getDb()
+  if (!db) return
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction('analysis', 'readwrite')
+    const store = tx.objectStore('analysis')
+    const req = store.put(value, key)
+    req.onsuccess = () => resolve()
+    req.onerror = () => reject(req.error)
   })
 }

--- a/apps/web/src/lib/file/cacheKey.ts
+++ b/apps/web/src/lib/file/cacheKey.ts
@@ -1,0 +1,3 @@
+export function cacheKeyForFile(file: File): string {
+  return `${file.name}-${file.size}-${file.lastModified}`
+}

--- a/apps/web/src/workers/waveform.worker.ts
+++ b/apps/web/src/workers/waveform.worker.ts
@@ -1,0 +1,63 @@
+import { int16ToFloat32 } from '../utils/pcm'
+
+interface GenerateMsg {
+  type: 'GEN_WAVEFORM'
+  payload: {
+    samples: ArrayBuffer
+    sampleRate: number
+    peakCount: number
+  }
+}
+
+interface DoneMsg {
+  type: 'WAVEFORM'
+  peaks: number[]
+}
+
+interface ErrorMsg {
+  type: 'ERROR'
+  error: string
+}
+
+self.onmessage = async (event: MessageEvent<GenerateMsg>) => {
+  const { type, payload } = event.data
+  if (type !== 'GEN_WAVEFORM') return
+  try {
+    const { samples, sampleRate, peakCount } = payload
+    let floatSamples = int16ToFloat32(samples)
+    let processed = floatSamples
+    if (typeof OfflineAudioContext !== 'undefined') {
+      try {
+        const ctx = new OfflineAudioContext(1, floatSamples.length, sampleRate)
+        const buffer = ctx.createBuffer(1, floatSamples.length, sampleRate)
+        buffer.getChannelData(0).set(floatSamples)
+        const src = ctx.createBufferSource()
+        src.buffer = buffer
+        src.connect(ctx.destination)
+        src.start()
+        const rendered = await ctx.startRendering()
+        processed = rendered.getChannelData(0)
+      } catch (err) {
+        console.warn('OfflineAudioContext failed in worker', err)
+      }
+    }
+    const len = peakCount
+    const step = processed.length / len
+    const peaks = new Array<number>(len)
+    for (let i = 0; i < len; i += 1) {
+      const start = Math.floor(i * step)
+      const end = Math.floor((i + 1) * step)
+      let max = 0
+      for (let j = start; j < end && j < processed.length; j += 1) {
+        const v = Math.abs(processed[j])
+        if (v > max) max = v
+      }
+      peaks[i] = max
+    }
+    const msg: DoneMsg = { type: 'WAVEFORM', peaks }
+    self.postMessage(msg)
+  } catch (err) {
+    const msg: ErrorMsg = { type: 'ERROR', error: (err as Error).message }
+    self.postMessage(msg)
+  }
+}


### PR DESCRIPTION
## Summary
- cache waveform arrays and thumbnails in IndexedDB
- compute waveforms in a dedicated worker
- capture the middle frame for thumbnail previews

## Testing
- `yarn lint` *(fails: Cannot find ESLint config)*
- `yarn test`