### PR TITLE
Fix ESLint peer dependencies

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -31,7 +31,7 @@
     "@types/react-dom": "^18.2.17",
     "@vitejs/plugin-react": "^4.4.1",
     "autoprefixer": "^10.4.21",
-    "eslint": "^9.25.0",
+    "eslint": "^8.57.0",
     "eslint-config-airbnb-typescript": "^18.0.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-import": "^2.29.1",
@@ -47,6 +47,8 @@
     "prettier": "^3.2.5",
     "tailwindcss": "^3.4.17",
     "typescript": "~5.8.3",
+    "@typescript-eslint/eslint-plugin": "^8.30.1",
+    "@typescript-eslint/parser": "^8.30.1",
     "typescript-eslint": "^8.30.1",
     "vite": "^6.3.5",
     "vitest": "^3.1.3"


### PR DESCRIPTION
## Summary
- install ESLint plugin dependencies and downgrade ESLint to a version compatible with eslint-config-airbnb-typescript

## Testing
- `yarn lint` *(fails: lint errors)*
- `yarn test`