### PR TITLE
Implement TrackRow skeleton with tests

### DIFF
--- a/apps/web/src/components/timeline/TrackRow.tsx
+++ b/apps/web/src/components/timeline/TrackRow.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react'
+import { Lock, Unlock, Eye, EyeOff, Volume2, VolumeX } from 'lucide-react'
+import { type Track, useTimelineStore } from '../../stores/timelineStore'
+
+interface TrackRowProps {
+  track: Track
+}
+
+export const TrackRow: React.FC<TrackRowProps> = ({ track }) => {
+  const updateTrack = useTimelineStore((s) => s.updateTrack)
+  const isAudio = track.type === 'audio'
+
+  const toggleLock = React.useCallback(() => {
+    updateTrack(track.id, { locked: !track.locked })
+  }, [updateTrack, track])
+
+  const toggleMute = React.useCallback(() => {
+    updateTrack(track.id, { muted: !track.muted })
+  }, [updateTrack, track])
+
+  const LockIcon = track.locked ? Lock : Unlock
+  const MuteIcon = track.muted
+    ? isAudio
+      ? VolumeX
+      : EyeOff
+    : isAudio
+      ? Volume2
+      : Eye
+
+  return (
+    <div className="flex bg-neutral-800 border-b border-neutral-700 text-white">
+      <div className="flex items-center justify-between w-48 px-2">
+        <span className="text-xs">{track.name}</span>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={toggleLock}
+            aria-label={track.locked ? 'Unlock track' : 'Lock track'}
+            className={track.locked ? 'opacity-50' : ''}
+          >
+            <LockIcon className="w-4 h-4" />
+          </button>
+          <button
+            type="button"
+            onClick={toggleMute}
+            aria-label={track.muted ? (isAudio ? 'Unmute track' : 'Show track') : (isAudio ? 'Mute track' : 'Hide track')}
+            className={track.muted ? 'opacity-50' : ''}
+          >
+            <MuteIcon className="w-4 h-4" />
+          </button>
+        </div>
+      </div>
+      <div className="relative flex-1" />
+    </div>
+  )
+}
+
+TrackRow.displayName = 'TrackRow'

--- a/apps/web/src/stubs/lucide-react.tsx
+++ b/apps/web/src/stubs/lucide-react.tsx
@@ -1,0 +1,57 @@
+import * as React from 'react'
+
+const iconProps = {
+  width: 16,
+  height: 16,
+  strokeWidth: 2,
+  stroke: 'currentColor',
+  fill: 'none',
+  strokeLinecap: 'round' as const,
+  strokeLinejoin: 'round' as const,
+}
+
+export const Lock = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 24 24" {...iconProps} {...props}>
+    <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+    <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+  </svg>
+)
+
+export const Unlock = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 24 24" {...iconProps} {...props}>
+    <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+    <path d="M7 11V7a5 5 0 0 1 9.84-1" />
+  </svg>
+)
+
+export const Eye = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 24 24" {...iconProps} {...props}>
+    <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8S1 12 1 12z" />
+    <circle cx="12" cy="12" r="3" />
+  </svg>
+)
+
+export const EyeOff = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 24 24" {...iconProps} {...props}>
+    <path d="M17.94 17.94A10.94 10.94 0 0 1 12 19c-7 0-11-7-11-7a17.3 17.3 0 0 1 5-5" />
+    <path d="M3 3l18 18" />
+  </svg>
+)
+
+export const Volume2 = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 24 24" {...iconProps} {...props}>
+    <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5" />
+    <path d="M15.54 8.46a5 5 0 0 1 0 7.07" />
+    <path d="M19.5 5a9 9 0 0 1 0 14" />
+  </svg>
+)
+
+export const VolumeX = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 24 24" {...iconProps} {...props}>
+    <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5" />
+    <line x1="22" y1="9" x2="16" y2="15" />
+    <line x1="16" y1="9" x2="22" y2="15" />
+  </svg>
+)
+
+// TODO(tauri-port): replace with real lucide-react once network install allowed

--- a/apps/web/src/tests/components/TrackRow.test.tsx
+++ b/apps/web/src/tests/components/TrackRow.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, afterEach, expect } from 'vitest'
+import { render, fireEvent, act } from '@testing-library/react'
+import React from 'react'
+
+import { TrackRow } from '../../components/timeline/TrackRow'
+import { useTimelineStore, type Track } from '../../stores/timelineStore'
+
+const resetStore = () => {
+  useTimelineStore.setState({ tracks: [], clips: {}, currentTime: 0, zoom: 100 })
+}
+
+describe('TrackRow', () => {
+  afterEach(() => resetStore())
+
+  it('toggles locked state when lock icon clicked', () => {
+    const track: Track = { id: 't1', name: 'V1', type: 'video', locked: false, muted: false }
+    act(() => {
+      useTimelineStore.setState({ tracks: [track], clips: {}, currentTime: 0, zoom: 100 })
+    })
+
+    const { rerender, getByLabelText } = render(<TrackRow track={track} />)
+
+    const lockBtn = getByLabelText('Lock track') as HTMLButtonElement
+    act(() => {
+      fireEvent.click(lockBtn)
+    })
+
+    const updated = useTimelineStore.getState().tracks[0]
+    expect(updated.locked).toBe(true)
+
+    rerender(<TrackRow track={updated} />)
+    expect(getByLabelText('Unlock track').className).toContain('opacity-50')
+  })
+})

--- a/apps/web/tsconfig.app.json
+++ b/apps/web/tsconfig.app.json
@@ -23,7 +23,11 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
 
-    "types": ["vitest", "vite/client"]
+    "types": ["vitest", "vite/client"],
+    "baseUrl": ".",
+    "paths": {
+      "lucide-react": ["./src/stubs/lucide-react.tsx"]
+    }
   },
   "include": ["src"]
 }

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -5,6 +5,11 @@ import { configDefaults } from 'vitest/config'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      'lucide-react': new URL('./src/stubs/lucide-react.tsx', import.meta.url).pathname,
+    },
+  },
   optimizeDeps: {
     // Prevent Vite from trying to pre-bundle FFmpeg which contains its own workers
     exclude: ['@ffmpeg/ffmpeg', '@ffmpeg/core'],

--- a/docs/schema-stub-strategy.md
+++ b/docs/schema-stub-strategy.md
@@ -46,6 +46,7 @@ These files compile but purposefully perform **no real work** yet. Each includes
 | `apps/web/src/state/yjsStore.ts` | `CollabProvider` | CRDT-powered realtime collaboration slice. |
 | `apps/web/src/lib/fs.ts` | `DesktopAdapter` | Swap browser FS API for Tauri native Rust bindings. |
 | `apps/web/src/lib/cache.ts` | `CacheLayer` | IndexedDB / OPFS media chunk caching with eviction. |
+| `apps/web/src/stubs/lucide-react.tsx` | `LucideIcons` | Placeholder icons before bundling real lucide-react. |
 
 ### Extending the Catalogue
 


### PR DESCRIPTION
## Summary
- stub lucide-react icons for offline dev
- expose alias in vite config and tsconfig
- document new stub in stub strategy
- add TrackRow timeline component skeleton
- test lock toggle behavior

## Testing
- `yarn lint` *(fails: Invalid option '--ext')*
- `yarn test`