### PR TITLE
Update track metadata and drop logic

### DIFF
--- a/apps/web/src/features/timeline/components/TrackRow.tsx
+++ b/apps/web/src/features/timeline/components/TrackRow.tsx
@@ -56,6 +56,13 @@ export const TrackRow: React.FC<TrackRowProps> = React.memo(({ laneIndex, clips,
       if (!assetId) return
       const asset = assets[assetId]
       if (!asset) return
+      const ext = asset.fileName.split('.').pop()?.toLowerCase() ?? ''
+      const audioRegex = /^(mp3|wav|flac|ogg|aac|m4a)$/
+      const videoRegex = /^(mp4|mov|mkv|webm|avi|mpg|mpeg)$/
+      const isAudio = audioRegex.test(ext)
+      const isVideoFile = videoRegex.test(ext)
+      const isAudioOnly = isAudio && !isVideoFile
+      const isVideo = isVideoFile || (!isAudio && !isVideoFile)
       const rect = e.currentTarget.getBoundingClientRect()
       const parentScroll = e.currentTarget.parentElement?.parentElement as HTMLElement
       const scrollLeft = parentScroll?.scrollLeft ?? 0
@@ -96,8 +103,12 @@ export const TrackRow: React.FC<TrackRowProps> = React.memo(({ laneIndex, clips,
         audioStart = Math.max(...conflictingAudioClips.map((clip: ClipType) => clip.end))
       }
 
-      addClip({ start: videoStart, end: videoStart + duration, lane: baseLane, assetId })
-      addClip({ start: audioStart, end: audioStart + duration, lane: audioLane, assetId })
+      if (isVideo) {
+        addClip({ start: videoStart, end: videoStart + duration, lane: baseLane, assetId })
+      }
+      if (isVideo || isAudioOnly) {
+        addClip({ start: audioStart, end: audioStart + duration, lane: audioLane, assetId })
+      }
       e.preventDefault()
     },
     [assets, pixelsPerSecond, laneIndex, addClip, clipsById],

--- a/apps/web/src/state/timelineStore.ts
+++ b/apps/web/src/state/timelineStore.ts
@@ -20,6 +20,8 @@ export interface Track {
   id: string
   type: 'video' | 'audio'
   label: string
+  /** id of the asset that originally created this track, if any */
+  parentAsset?: string
 }
 
 export interface TimelineState {
@@ -60,9 +62,9 @@ const ensureTracks = (tracks: Track[], lane: number): Track[] => {
   const next = [...tracks]
   while (next.length <= lane) {
     const index = next.length
-    const pair = Math.floor(index / 2) + 1
     const type = index % 2 === 0 ? 'video' : 'audio'
-    const label = type === 'video' ? `V${pair}` : `A${pair}`
+    const countOfType = next.filter((t) => t.type === type).length + 1
+    const label = type === 'video' ? `V${countOfType}` : `A${countOfType}`
     next.push({ id: `track-${index}`, type, label })
   }
   return next


### PR DESCRIPTION
## Summary
- extend `Track` with optional `parentAsset` field
- compute track labels by counting existing tracks of each type
- drop handler checks asset info and only creates needed audio/video clips
- render track rows and labels directly from `tracks` data

## Testing
- `yarn lint` *(fails: Invalid option '--ext')*
- `yarn test`