### PR TITLE
Enable space-drag mode for zoom scroll

### DIFF
--- a/apps/web/src/features/timeline/hooks/useZoomScroll.ts
+++ b/apps/web/src/features/timeline/hooks/useZoomScroll.ts
@@ -32,10 +32,25 @@ export function useZoomScroll(
   const velocity = useRef(0)
   const lastPos = useRef(0)
   const lastTime = useRef(0)
+  const spacePressed = useRef(false)
 
   useEffect(() => {
     const el = containerRef.current
     if (!el) return
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.code === 'Space') {
+        spacePressed.current = true
+        e.preventDefault()
+      }
+    }
+
+    const handleKeyUp = (e: KeyboardEvent) => {
+      if (e.code === 'Space') {
+        spacePressed.current = false
+        e.preventDefault()
+      }
+    }
 
     // Handle zoom via Ctrl+Wheel or pinch gestures
     const handleWheel = (e: WheelEvent) => {
@@ -75,8 +90,8 @@ export function useZoomScroll(
 
     // Handle click-and-drag scrolling
     const handlePointerDown = (e: PointerEvent) => {
-      // Allow left-button (space-drag planned) and middle-button panning
-      if (e.button !== 0 && e.button !== 1) return
+      // Start dragging only with middle button or while holding space + left button
+      if (!(e.button === 1 || (e.button === 0 && spacePressed.current))) return
       isDragging.current = true
       el.setPointerCapture(e.pointerId)
       startX.current = e.clientX
@@ -121,6 +136,8 @@ export function useZoomScroll(
       momentum()
     }
 
+    window.addEventListener('keydown', handleKeyDown)
+    window.addEventListener('keyup', handleKeyUp)
     el.addEventListener('wheel', handleWheel, { passive: false })
     el.addEventListener('pointerdown', handlePointerDown)
     el.addEventListener('pointermove', handlePointerMove)
@@ -128,6 +145,8 @@ export function useZoomScroll(
     el.addEventListener('pointercancel', handlePointerUp)
 
     return () => {
+      window.removeEventListener('keydown', handleKeyDown)
+      window.removeEventListener('keyup', handleKeyUp)
       el.removeEventListener('wheel', handleWheel)
       el.removeEventListener('pointerdown', handlePointerDown)
       el.removeEventListener('pointermove', handlePointerMove)

--- a/apps/web/src/tests/timeline/useZoomScroll.test.tsx
+++ b/apps/web/src/tests/timeline/useZoomScroll.test.tsx
@@ -87,7 +87,7 @@ describe('useZoomScroll', () => {
     expect(el.scrollLeft).toBeCloseTo(125)
   })
 
-  it('pans horizontally on pointer drag', () => {
+  it('does not pan on left drag without space held', () => {
     const { getByTestId } = render(<TestComponent />)
     const el = getByTestId('scroll') as HTMLDivElement
     el.getBoundingClientRect = () => ({
@@ -109,6 +109,80 @@ describe('useZoomScroll', () => {
           clientX: 100,
           pointerId: 1,
           button: 0,
+        }),
+      )
+      el.dispatchEvent(
+        createPointerEvent('pointermove', {
+          clientX: 50,
+          pointerId: 1,
+        }),
+      )
+      vi.advanceTimersByTime(20)
+    })
+
+    expect(el.scrollLeft).toBeCloseTo(100)
+  })
+
+  it('pans on left drag when space is held', () => {
+    const { getByTestId } = render(<TestComponent />)
+    const el = getByTestId('scroll') as HTMLDivElement
+    el.getBoundingClientRect = () => ({
+      left: 0,
+      top: 0,
+      width: 200,
+      height: 20,
+      right: 200,
+      bottom: 20,
+      x: 0,
+      y: 0,
+      toJSON() {},
+    })
+    el.scrollLeft = 100
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { code: 'Space', bubbles: true }))
+      el.dispatchEvent(
+        createPointerEvent('pointerdown', {
+          clientX: 100,
+          pointerId: 1,
+          button: 0,
+        }),
+      )
+      el.dispatchEvent(
+        createPointerEvent('pointermove', {
+          clientX: 50,
+          pointerId: 1,
+        }),
+      )
+      vi.advanceTimersByTime(20)
+      window.dispatchEvent(new KeyboardEvent('keyup', { code: 'Space', bubbles: true }))
+    })
+
+    expect(el.scrollLeft).toBeCloseTo(150)
+  })
+
+  it('pans on middle button drag', () => {
+    const { getByTestId } = render(<TestComponent />)
+    const el = getByTestId('scroll') as HTMLDivElement
+    el.getBoundingClientRect = () => ({
+      left: 0,
+      top: 0,
+      width: 200,
+      height: 20,
+      right: 200,
+      bottom: 20,
+      x: 0,
+      y: 0,
+      toJSON() {},
+    })
+    el.scrollLeft = 100
+
+    act(() => {
+      el.dispatchEvent(
+        createPointerEvent('pointerdown', {
+          clientX: 100,
+          pointerId: 1,
+          button: 1,
         }),
       )
       el.dispatchEvent(


### PR DESCRIPTION
## Summary
- track `spacePressed` in `useZoomScroll`
- require space key or middle mouse button to start drag
- extend `useZoomScroll` tests for new behaviour

## Testing
- `yarn lint` *(fails: Invalid option '--ext')*
- `yarn test`