### PR TITLE
Improve TimeRuler tick spacing

### DIFF
--- a/apps/web/src/tests/timeline/timeRulerTicks.test.ts
+++ b/apps/web/src/tests/timeline/timeRulerTicks.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest'
+import { calculateTickSettings } from '../../features/timeline/components/TimeRuler'
+
+describe('calculateTickSettings', () => {
+  it('skips labels when spacing would be under 20px', () => {
+    const pps = 0.25
+    const { major, labelEvery } = calculateTickSettings(pps)
+    expect(major * labelEvery * pps).toBeGreaterThanOrEqual(20)
+    expect(labelEvery).toBeGreaterThan(1)
+  })
+
+  it('shows every label when spacing is sufficient', () => {
+    const { labelEvery } = calculateTickSettings(100)
+    expect(labelEvery).toBe(1)
+  })
+})


### PR DESCRIPTION
## Summary
- adjust major tick algorithm and expose `calculateTickSettings`
- skip ruler labels when projected spacing is too small
- test tick spacing for very small zoom levels

## Testing
- `CI=1 npx vitest run --silent`