### PR TITLE
Implement basic yjs store

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,7 @@ With the dev server running, open your browser to `http://localhost:5173`. Use t
 - **Drag and trim clips** – clips can be moved along the timeline and resized from either edge. Snapping helps align edits to beats and neighbouring clips.
 - **Zoomable view** – scroll or pinch while holding <kbd>Ctrl</kbd> to zoom, or use the zoom slider. The timeline can also be panned by dragging.
 - **Keyboard shortcuts** – J, K and L shuttle playback; the arrow keys jog the playhead; press **I** and **O** to set in/out points; press **C** to cut the clip under the playhead.
+
+## Collaboration stubs
+
+This prototype uses lightweight local stubs for the `yjs` and `y-protocols/awareness` packages. The stubs implement minimal `Doc` and `Awareness` classes so tests compile without pulling in the real libraries. When realtime collaboration work begins, swap these for the official modules and remove the stubs.

--- a/apps/web/src/state/yjsStore.ts
+++ b/apps/web/src/state/yjsStore.ts
@@ -1,26 +1,38 @@
 import { create } from 'zustand'
+import * as Y from 'yjs'
+import { Awareness } from 'y-protocols/awareness'
 
 interface YjsState {
-  doc: unknown | null
-  awareness: { states: Map<number, any> } | null
+  doc: Y.Doc | null
+  awareness: Awareness | null
   connected: boolean
   setConnected: (connected: boolean) => void
-  setDoc: (doc: unknown) => void
+  setDoc: (doc: Y.Doc) => void
+  applyUpdate: (update: Uint8Array) => void
+  broadcastAwareness: (state: any) => void
 }
 
-const createDoc = () => ({})
-const createAwareness = () => ({ states: new Map<number, any>() })
+const createDoc = () => new Y.Doc()
+const createAwareness = (doc: Y.Doc) => new Awareness(doc)
 
-export const useYjsStore = create<YjsState>((set) => ({
+export const useYjsStore = create<YjsState>((set, get) => ({
   doc: null,
   awareness: null,
   connected: false,
   setConnected: (connected) => set({ connected }),
   setDoc: (doc) => set({ doc }),
+  applyUpdate: (update) => {
+    const { doc } = get()
+    if (doc) Y.applyUpdate(doc, update)
+  },
+  broadcastAwareness: (state) => {
+    const { awareness } = get()
+    awareness?.setLocalState(state)
+  },
 }))
 
 export const initYjsStore = () => {
   const doc = createDoc()
-  const awareness = createAwareness()
+  const awareness = createAwareness(doc)
   useYjsStore.setState({ doc, awareness, connected: true })
 }

--- a/apps/web/src/stubs/awareness.ts
+++ b/apps/web/src/stubs/awareness.ts
@@ -1,0 +1,12 @@
+import type { Doc } from './yjs'
+
+export class Awareness {
+  states = new Map<number, any>()
+  doc: Doc
+  constructor(doc: Doc) {
+    this.doc = doc
+  }
+  setLocalState(state: any) {
+    this.states.set(0, state)
+  }
+}

--- a/apps/web/src/stubs/yjs.ts
+++ b/apps/web/src/stubs/yjs.ts
@@ -1,0 +1,29 @@
+export class Doc {
+  maps: Record<string, Map<string, any>> = {}
+  getMap<T = any>(name: string): Map<string, T> {
+    if (!this.maps[name]) {
+      this.maps[name] = new Map()
+    }
+    return this.maps[name] as Map<string, T>
+  }
+}
+
+export function applyUpdate(doc: Doc, update: Uint8Array) {
+  const text = new TextDecoder().decode(update)
+  const data = JSON.parse(text || '{}') as Record<string, Record<string, any>>
+  Object.entries(data).forEach(([mapName, entries]) => {
+    const map = doc.getMap(mapName)
+    Object.entries(entries).forEach(([k, v]) => {
+      map.set(k, v)
+    })
+  })
+}
+
+export function encodeStateAsUpdate(doc: Doc): Uint8Array {
+  const obj: Record<string, Record<string, any>> = {}
+  Object.entries(doc.maps).forEach(([name, map]) => {
+    obj[name] = Object.fromEntries(map.entries())
+  })
+  const json = JSON.stringify(obj)
+  return new TextEncoder().encode(json)
+}

--- a/apps/web/src/tests/stores/yjsStoreSync.test.ts
+++ b/apps/web/src/tests/stores/yjsStoreSync.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest'
+import * as Y from 'yjs'
+import { initYjsStore, useYjsStore } from '../../state/yjsStore'
+
+
+describe('yjs store sync', () => {
+  it('applies document and awareness updates', () => {
+    initYjsStore()
+    const other = new Y.Doc()
+    const map = other.getMap<any>('data')
+    map.set('foo', 'bar')
+
+    const update = Y.encodeStateAsUpdate(other)
+    useYjsStore.getState().applyUpdate(update)
+
+    const doc = useYjsStore.getState().doc!
+    expect(doc.getMap<any>('data').get('foo')).toBe('bar')
+
+    useYjsStore.getState().broadcastAwareness({ user: 1 })
+    const awareness = useYjsStore.getState().awareness!
+    expect(awareness.states.get(0)).toEqual({ user: 1 })
+  })
+})

--- a/apps/web/tsconfig.app.json
+++ b/apps/web/tsconfig.app.json
@@ -26,7 +26,9 @@
     "types": ["vitest", "vite/client"],
     "baseUrl": ".",
     "paths": {
-      "lucide-react": ["./src/stubs/lucide-react.tsx"]
+      "lucide-react": ["./src/stubs/lucide-react.tsx"],
+      "yjs": ["./src/stubs/yjs.ts"],
+      "y-protocols/awareness": ["./src/stubs/awareness.ts"]
     }
   },
   "include": ["src"]

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -8,6 +8,8 @@ export default defineConfig({
   resolve: {
     alias: {
       'lucide-react': new URL('./src/stubs/lucide-react.tsx', import.meta.url).pathname,
+      'yjs': new URL('./src/stubs/yjs.ts', import.meta.url).pathname,
+      'y-protocols/awareness': new URL('./src/stubs/awareness.ts', import.meta.url).pathname,
     },
   },
   optimizeDeps: {


### PR DESCRIPTION
## Summary
- add simple Yjs stubs and map to them in tsconfig and Vite
- implement real doc and awareness instances in yjsStore
- expose update and awareness methods
- test sync behaviour via yjsStore
- document yjs stubs in README

## Testing
- `yarn lint` *(fails: Invalid option '--ext')*
- `yarn test --run`