### PR TITLE
Refactor media ingest asset registration

### DIFF
--- a/apps/web/src/features/import/MediaIngest.tsx
+++ b/apps/web/src/features/import/MediaIngest.tsx
@@ -3,8 +3,6 @@ import useMotifStore from '../../lib/store'
 import { extractVideoMetadata } from '../../lib/file/extractVideoMetadata'
 import type { VideoMetadata } from '../../lib/file/extractVideoMetadata'
 import { useMediaStore } from '../../state/mediaStore'
-import { generateWaveform } from '../../lib/file/generateWaveform'
-import { captureThumbnail } from '../../lib/file/captureThumbnail'
 
 const defaultMetadata: VideoMetadata = {
   duration: null,
@@ -37,20 +35,7 @@ export default function MediaIngest() {
               id: assetId,
               fileName: file.name,
               duration: metadata.duration ?? 0,
-            })
-            let waveform: number[] | undefined
-            let thumbnail: string | undefined
-            try {
-              ;[waveform, thumbnail] = await Promise.all([
-                generateWaveform(file),
-                captureThumbnail(file),
-              ])
-            } catch (err) {
-              console.warn('Media analysis failed', err)
-            }
-            useMediaStore.getState().updateAsset(assetId, {
-              waveform: waveform && waveform.length > 0 ? waveform : [0],
-              thumbnail: thumbnail ?? 'data:image/placeholder',
+              file,
             })
           }
         } catch (err) {

--- a/apps/web/src/features/import/VideoImportButton.tsx
+++ b/apps/web/src/features/import/VideoImportButton.tsx
@@ -10,8 +10,6 @@ import { useBeatDetection } from '../../lib/store/hooks'
 import type { BeatMarker } from '../../lib/store/types'
 import { BeatDetectionProgress } from './BeatDetectionProgress'
 import { useMediaStore } from '../../state/mediaStore'
-import { generateWaveform } from '../../lib/file/generateWaveform'
-import { captureThumbnail } from '../../lib/file/captureThumbnail'
 
 export function VideoImportButton() {
   const { isFileLoading, fileError, setFileInfo } = useFileState()
@@ -69,13 +67,8 @@ export function VideoImportButton() {
           id: assetId,
           fileName: file.name,
           duration: metadata.duration ?? 0,
+          file,
         })
-        const assetId = useMediaStore.getState().addAsset({
-          fileName: file.name,
-          duration: metadata.duration ?? 0,
-        })
-
-        if (assetId) {
 
         if ((metadata.duration ?? 0) > 600) {
           try {
@@ -87,18 +80,7 @@ export function VideoImportButton() {
             console.warn('Proxy generation failed', err)
           }
         }
-        try {
-          const [waveform, thumbnail] = await Promise.all([
-            generateWaveform(file),
-            captureThumbnail(file),
-          ])
-          useMediaStore.getState().updateAsset(assetId, {
-            waveform,
-            thumbnail,
-          })
-        } catch (analysisErr) {
-          console.warn('Media analysis failed', analysisErr)
-        }
+      }
         try {
           const { videoSupported, audioSupported } = await checkCodecSupport({
             width: metadata.width ?? undefined,

--- a/apps/web/src/tests/MediaIngest.test.tsx
+++ b/apps/web/src/tests/MediaIngest.test.tsx
@@ -19,12 +19,6 @@ vi.mock('../lib/file/extractVideoMetadata', () => ({
     channelCount: null,
   }),
 }))
-vi.mock('../lib/file/generateWaveform', () => ({
-  generateWaveform: vi.fn().mockResolvedValue([0.1, 0.2]),
-}))
-vi.mock('../lib/file/captureThumbnail', () => ({
-  captureThumbnail: vi.fn().mockResolvedValue('data:image/png;base64,test'),
-}))
 
 const resetStores = () => {
   useMotifStore.getState().resetState()
@@ -65,8 +59,7 @@ describe('MediaIngest', () => {
       expect(clips[1].assetId).toBeDefined()
       const assets = useMediaStore.getState().assets
       const asset = assets[clips[0].assetId as string]
-      expect(asset.waveform?.length).toBeGreaterThan(0)
-      expect(asset.thumbnail).toContain('data:image')
+      expect(asset).toBeDefined()
     })
 
     const clips = Object.values(useTimelineStore.getState().clipsById)
@@ -75,8 +68,6 @@ describe('MediaIngest', () => {
     const { container: vCont } = render(
       <Clip clip={videoClip} pixelsPerSecond={100} type="video" />,
     )
-    const videoDiv = vCont.querySelector('div') as HTMLDivElement
-    expect(videoDiv.style.backgroundImage).toContain('data:image')
     const { container: aCont } = render(
       <Clip clip={audioClip} pixelsPerSecond={100} type="audio" />,
     )


### PR DESCRIPTION
## Summary
- register assets through `useMediaStore` once using provided id and file
- drop manual waveform/thumbnail generation logic
- adjust tests for new behaviour

## Testing
- `yarn lint` *(fails: Invalid option '--ext')*
- `yarn test`