### PR TITLE
Clamp tooltip in TimeRuler

### DIFF
--- a/apps/web/src/features/timeline/components/TimeRuler.tsx
+++ b/apps/web/src/features/timeline/components/TimeRuler.tsx
@@ -136,6 +136,7 @@ export const TimeRuler: React.FC<TimeRulerProps> = ({
 
   const canvasRef = React.useRef<HTMLCanvasElement>(null)
   const containerRef = React.useRef<HTMLDivElement>(null)
+  const tooltipRef = React.useRef<HTMLDivElement>(null)
 
   const [tooltip, setTooltip] = React.useState<{
     visible: boolean
@@ -241,12 +242,20 @@ export const TimeRuler: React.FC<TimeRulerProps> = ({
   /* --------------- tooltip handlers ----------------------------------- */
   const onMouseMove = React.useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
-      const rect = e.currentTarget.getBoundingClientRect()
+      const container = containerRef.current
+      if (!container) return
+      const rect = container.getBoundingClientRect()
       const localX = e.clientX - rect.left
       const absoluteX = localX + scrollLeft
+      const width = container.clientWidth
+      const tooltipW = tooltipRef.current?.clientWidth ?? 0
+      const clampedX = Math.min(
+        Math.max(localX, 0),
+        width - tooltipW,
+      )
       setTooltip({
         visible: true,
-        x: localX,
+        x: clampedX,
         time: absoluteX / pixelsPerSecond,
       })
     },
@@ -290,6 +299,7 @@ export const TimeRuler: React.FC<TimeRulerProps> = ({
       {/* hover timecode tooltip */}
       {tooltip.visible && (
         <div
+          ref={tooltipRef}
           className="pointer-events-none absolute -top-6 rounded bg-gray-800/90 px-1 py-0.5 font-mono text-[10px] text-white"
           style={{ left: tooltip.x }}
         >

--- a/apps/web/src/tests/timeline/timeRulerTooltip.test.tsx
+++ b/apps/web/src/tests/timeline/timeRulerTooltip.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, fireEvent, act } from '@testing-library/react'
+import React from 'react'
+import { TimeRuler } from '../../features/timeline/components/TimeRuler'
+import { useTimelineStore } from '../../state/timelineStore'
+
+const resetStore = () => {
+  useTimelineStore.setState({
+    clipsById: {},
+    tracks: [],
+    durationSec: 0,
+    currentTime: 0,
+    followPlayhead: true,
+    inPoint: null,
+    outPoint: null,
+    beats: [],
+  })
+}
+
+describe('TimeRuler tooltip clamping', () => {
+  afterEach(() => {
+    resetStore()
+  })
+
+  it('clamps tooltip within container bounds', () => {
+    const scrollRef = React.createRef<HTMLDivElement>()
+    const { container } = render(
+      <>
+        <div ref={scrollRef} />
+        <TimeRuler scrollContainerRef={scrollRef} pixelsPerSecond={100} duration={10} />
+      </>
+    )
+
+    const rulerDiv = container.querySelector('canvas')!.parentElement!.parentElement as HTMLDivElement
+
+    Object.defineProperty(rulerDiv, 'getBoundingClientRect', {
+      value: () => ({ left: 0, top: 0, width: 100, height: 6, right: 100, bottom: 6 }),
+    })
+    Object.defineProperty(rulerDiv, 'clientWidth', { value: 100 })
+
+    act(() => {
+      fireEvent.mouseMove(rulerDiv, { clientX: 95 })
+    })
+
+    let tooltip = rulerDiv.querySelector('.pointer-events-none') as HTMLDivElement
+    expect(tooltip).not.toBeNull()
+    Object.defineProperty(tooltip, 'clientWidth', { value: 40 })
+
+    act(() => {
+      fireEvent.mouseMove(rulerDiv, { clientX: 95 })
+    })
+
+    tooltip = rulerDiv.querySelector('.pointer-events-none') as HTMLDivElement
+    expect(tooltip.style.left).toBe('60px')
+  })
+})


### PR DESCRIPTION
## Summary
- keep TimeRuler tooltip within container bounds
- test tooltip clamping

## Testing
- `yarn test`