### PR TITLE
Enable playhead drag scrubbing

### DIFF
--- a/apps/web/src/features/timeline/components/Playhead.tsx
+++ b/apps/web/src/features/timeline/components/Playhead.tsx
@@ -10,6 +10,10 @@ interface PlayheadProps {
   height: number | string
   /** Scroll offset to subtract when overlaid */
   offsetX?: number
+  /** Pointer down handler for scrubbing */
+  onPointerDown?: (e: React.PointerEvent<HTMLDivElement>) => void
+  /** Enable pointer events when interactive */
+  interactive?: boolean
 }
 
 /**
@@ -22,14 +26,17 @@ interface PlayheadProps {
  * @param offsetX horizontal scroll offset when overlaid
  * @returns visual playhead line element
  */
-export const Playhead: React.FC<PlayheadProps> = React.memo(({ positionSeconds, pixelsPerSecond, height, offsetX = 0 }) => {
-  const x = positionSeconds * pixelsPerSecond - offsetX
-  return (
-    <div
-      className="absolute top-0 w-0.5 bg-accent pointer-events-none"
-      style={{ height, transform: `translateX(${x}px)` }}
-    />
-  )
-})
+export const Playhead: React.FC<PlayheadProps> = React.memo(
+  ({ positionSeconds, pixelsPerSecond, height, offsetX = 0, onPointerDown, interactive = false }) => {
+    const x = positionSeconds * pixelsPerSecond - offsetX
+    return (
+      <div
+        onPointerDown={interactive ? onPointerDown : undefined}
+        className={`absolute top-0 w-0.5 bg-accent ${interactive ? 'cursor-ew-resize' : 'pointer-events-none'}`}
+        style={{ height, transform: `translateX(${x}px)` }}
+      />
+    )
+  },
+)
 
 Playhead.displayName = 'Playhead' 

--- a/apps/web/src/features/timeline/components/Timeline.tsx
+++ b/apps/web/src/features/timeline/components/Timeline.tsx
@@ -68,6 +68,7 @@ export const Timeline: React.FC<TimelineProps> = React.memo(({ pixelsPerSecond =
 
   const playheadFrame = useTransportStore((s) => s.playheadFrame)
   const playRate = useTransportStore((s) => s.playRate)
+  const playing = playRate !== 0
   const setCurrentTime = useTimelineStore((s) => s.setCurrentTime)
   const currentTime = useTimelineStore((s) => s.currentTime)
   const followPlayhead = useTimelineStore((s) => s.followPlayhead)
@@ -241,7 +242,14 @@ export const Timeline: React.FC<TimelineProps> = React.memo(({ pixelsPerSecond =
                 ))}
               </div>
             </div>
-            <Playhead positionSeconds={playheadSeconds} pixelsPerSecond={zoom} height="100%" offsetX={scrollLeft} />
+            <Playhead
+              positionSeconds={playheadSeconds}
+              pixelsPerSecond={zoom}
+              height="100%"
+              offsetX={scrollLeft}
+              onPointerDown={startScrub}
+              interactive={!playing}
+            />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- allow Playhead component to start scrubbing on pointer down
- update Timeline to pass scrubbing handler and disable pointer events while playing

## Testing
- `yarn lint` *(fails: 1322 problems)*
- `yarn test`