### PR TITLE
Implement playhead and cross-track snapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ With the dev server running, open your browser to `http://localhost:5173`. Use t
 ## Timeline features
 
 - **Drag and trim clips** – clips can be moved along the timeline and resized from either edge. Snapping helps align edits to beats and neighbouring clips.
+- **Global snapping** – clip edges also snap to clips on other tracks and to the current playhead position for easy alignment.
 - **Zoomable view** – scroll or pinch while holding <kbd>Ctrl</kbd> to zoom, or use the zoom slider. The timeline can also be panned by dragging.
 - **Keyboard shortcuts** – J, K and L shuttle playback; the arrow keys jog the playhead; press **I** and **O** to set in/out points; press **C** to cut the clip under the playhead.
 

--- a/apps/web/src/features/timeline/components/InteractiveClip.tsx
+++ b/apps/web/src/features/timeline/components/InteractiveClip.tsx
@@ -7,6 +7,7 @@ import type { Clip as ClipType } from '../../../state/timelineStore'
 import {
   useTimelineStore,
   selectLaneClips,
+  selectClipsArray,
 } from '../../../state/timelineStore'
 import { useMediaStore } from '../../../state/mediaStore'
 import { useLaneClips } from '../hooks/useLaneClips'
@@ -69,17 +70,24 @@ export const InteractiveClip: React.FC<InteractiveClipProps> = React.memo(
     // ------------------------------------------------------------------------
 
     const laneClips = useLaneClips(clip.lane)
-    const neighborTimes = React.useMemo(
+    const clipsById = useTimelineStore((s) => s.clipsById)
+    const allClips = React.useMemo(
+      () => selectClipsArray({ clipsById } as any),
+      [clipsById],
+    )
+    const playheadTime = useTimelineStore((s) => s.currentTime)
+
+    const globalTimes = React.useMemo(
       () =>
-        laneClips
+        allClips
           .filter((c) => c.id !== clip.id)
           .flatMap((c) => [c.start, c.end]),
-      [laneClips, clip.id],
+      [allClips, clip.id],
     )
 
     const snapCandidates = React.useMemo(
-      () => [...beats, ...neighborTimes],
-      [beats, neighborTimes],
+      () => [...beats, ...globalTimes, playheadTime],
+      [beats, globalTimes, playheadTime],
     )
 
     const findSnap = React.useCallback(


### PR DESCRIPTION
## Summary
- gather all clip times using `selectClipsArray`
- include playhead time in snap candidates
- document the new snapping behaviour
- clean up InteractiveClip tests

## Testing
- `yarn lint` *(fails: eslint errors)*
- `yarn test` *(passed with warnings)*