### PR TITLE
Finish MediaLibrary drag/drop

### DIFF
--- a/apps/web/src/features/import/MediaLibrary.tsx
+++ b/apps/web/src/features/import/MediaLibrary.tsx
@@ -2,28 +2,20 @@ import React from 'react'
 import { useMediaStore } from '../../state/mediaStore'
 import { useTimelineStore } from '../../state/timelineStore'
 import { Button } from '../../components/ui/Button'
+import { insertAssetToTimeline } from '../timeline/utils'
 
 export default function MediaLibrary() {
   const assetsObject = useMediaStore((s) => s.assets)
   const assets = React.useMemo(() => Object.values(assetsObject), [assetsObject])
   const removeAsset = useMediaStore((s) => s.removeAsset)
-  const addClip = useTimelineStore((s) => s.addClip)
-  const clipsById = useTimelineStore((s) => s.clipsById)
-  const removeClip = useTimelineStore((s) => s.removeClip)
+  const removeClipsByAsset = useTimelineStore((s) => s.removeClipsByAsset)
 
-  const handleAdd = (id: string, duration: number) => {
-    const maxLane = Object.values(clipsById).reduce((m, c) => Math.max(m, c.lane), -1)
-    const baseLane = maxLane + 1
-    addClip({ start: 0, end: duration, lane: baseLane, assetId: id })
-    addClip({ start: 0, end: duration, lane: baseLane + 1, assetId: id })
+  const handleAdd = (id: string) => {
+    insertAssetToTimeline(id)
   }
 
   const handleRemove = (id: string) => {
-    Object.entries(clipsById).forEach(([cid, c]) => {
-      if (c.assetId === id) {
-        removeClip(cid)
-      }
-    })
+    removeClipsByAsset(id)
     removeAsset(id)
   }
 
@@ -33,6 +25,46 @@ export default function MediaLibrary() {
     <div className="space-y-2">
       <h3 className="text-ui-body font-ui-medium text-accent">Media Library</h3>
       <ul className="space-y-2">
+        {assets.map((asset) => (
+          <li
+            key={asset.id}
+            className="flex items-center gap-2 p-2 bg-panel-bg rounded"
+            draggable
+            onDragStart={(e) =>
+              e.dataTransfer.setData('text/x-mediamix-asset', asset.id)
+            }
+          >
+            {asset.thumbnail && (
+              <img
+                src={asset.thumbnail}
+                alt="thumbnail"
+                className="w-10 h-10 object-cover rounded"
+              />
+            )}
+            <div className="flex-1 overflow-hidden">
+              <div className="text-xs text-gray-200 truncate">
+                {asset.fileName}
+              </div>
+              <div className="text-xs text-gray-400">
+                {asset.duration.toFixed(2)}s
+              </div>
+            </div>
+            <Button
+              variant="secondary"
+              className="px-2 py-1 text-xs"
+              onClick={() => handleAdd(asset.id)}
+            >
+              Add
+            </Button>
+            <Button
+              variant="secondary"
+              className="px-2 py-1 text-xs"
+              onClick={() => handleRemove(asset.id)}
+            >
+              Remove
+            </Button>
+          </li>
+        ))}
       </ul>
     </div>
   )

--- a/apps/web/src/features/timeline/components/TrackRow.tsx
+++ b/apps/web/src/features/timeline/components/TrackRow.tsx
@@ -2,8 +2,7 @@ import * as React from 'react'
 import type { Clip as ClipType, Track } from '../../../state/timelineStore'
 import { useTimelineStore } from '../../../state/timelineStore'
 import { Lock, Unlock, Eye, EyeOff, Volume2, VolumeX } from 'lucide-react'
-import { nanoid } from '../../../utils/nanoid'
-import { useMediaStore } from '../../../state/mediaStore'
+import { insertAssetToTimeline } from '../utils'
 import { InteractiveClip } from './InteractiveClip'
 
 /** Props for {@link TrackRow}. */
@@ -30,9 +29,6 @@ export const TrackRow: React.FC<TrackRowProps> = React.memo(({ laneIndex, clips,
   const type = track.type
   const height = type === 'video' ? 48 : 32
 
-  const addClip = useTimelineStore((s) => s.addClip)
-  const clipsById = useTimelineStore((s) => s.clipsById)
-  const assets = useMediaStore((s) => s.assets)
   const updateTrack = useTimelineStore((s) => s.updateTrack)
 
   const isAudio = type === 'audio'
@@ -76,67 +72,12 @@ export const TrackRow: React.FC<TrackRowProps> = React.memo(({ laneIndex, clips,
   const handleDrop = React.useCallback(
     (e: React.DragEvent<HTMLDivElement>) => {
       const assetId = e.dataTransfer.getData('text/x-mediamix-asset')
-      if (!assetId) return
-      const asset = assets[assetId]
-      if (!asset) return
-      const ext = asset.fileName.split('.').pop()?.toLowerCase() ?? ''
-      const audioRegex = /^(mp3|wav|flac|ogg|aac|m4a)$/
-      const videoRegex = /^(mp4|mov|mkv|webm|avi|mpg|mpeg)$/
-      const isAudio = audioRegex.test(ext)
-      const isVideoFile = videoRegex.test(ext)
-      const isAudioOnly = isAudio && !isVideoFile
-      const isVideo = isVideoFile || (!isAudio && !isVideoFile)
-      const rect = e.currentTarget.getBoundingClientRect()
-      const parentScroll = e.currentTarget.parentElement?.parentElement as HTMLElement
-      const scrollLeft = parentScroll?.scrollLeft ?? 0
-      const x = e.clientX - rect.left + scrollLeft
-      const initialStart = Math.max(0, x / pixelsPerSecond)
-      const duration = asset.duration
-      const initialEnd = initialStart + duration
-
-      const allClipsArray = Object.values(clipsById)
-
-      const groupId = nanoid()
-
-      const calcStart = (lane: number): number => {
-        const conflicts = allClipsArray.filter(
-          (clip: ClipType) =>
-            clip.lane === lane &&
-            clip.start < initialEnd &&
-            clip.end > initialStart,
-        )
-        if (conflicts.length > 0) {
-          return Math.max(...conflicts.map((c) => c.end))
-        }
-        return initialStart
+      if (assetId) {
+        insertAssetToTimeline(assetId)
+        e.preventDefault()
       }
-
-      if (isVideo) {
-        const videoLane = type === 'video' ? laneIndex : Math.max(0, laneIndex - 1)
-        const audioLane = videoLane + 1
-        const videoStart = calcStart(videoLane)
-        const audioStart = calcStart(audioLane)
-        addClip(
-          { start: videoStart, end: videoStart + duration, lane: videoLane, assetId },
-          { trackType: 'video', groupId },
-        )
-        if (!isAudioOnly) {
-          addClip(
-            { start: audioStart, end: audioStart + duration, lane: audioLane, assetId },
-            { trackType: 'audio', groupId },
-          )
-        }
-      } else {
-        const audioLane = type === 'audio' ? laneIndex : laneIndex + 1
-        const audioStart = calcStart(audioLane)
-        addClip(
-          { start: audioStart, end: audioStart + duration, lane: audioLane, assetId },
-          { trackType: 'audio', groupId },
-        )
-      }
-      e.preventDefault()
     },
-    [assets, pixelsPerSecond, laneIndex, addClip, clipsById, type],
+    []
   )
 
   return (

--- a/apps/web/src/features/timeline/utils.ts
+++ b/apps/web/src/features/timeline/utils.ts
@@ -1,0 +1,35 @@
+import { nanoid } from '../../utils/nanoid'
+import { useMediaStore } from '../../state/mediaStore'
+import { useTimelineStore } from '../../state/timelineStore'
+
+export function insertAssetToTimeline(assetId: string) {
+  const { assets } = useMediaStore.getState()
+  const asset = assets[assetId]
+  if (!asset) return
+
+  const timeline = useTimelineStore.getState()
+  const { addClip, tracks } = timeline
+
+  const ext = asset.fileName.split('.').pop()?.toLowerCase() ?? ''
+  const audioOnly = /^(mp3|wav|flac|ogg|aac|m4a)$/.test(ext)
+  const duration = asset.duration
+
+  let baseLane = tracks.length
+  const groupId = nanoid()
+
+  if (audioOnly) {
+    addClip(
+      { start: 0, end: duration, lane: baseLane, assetId },
+      { trackType: 'audio', groupId },
+    )
+  } else {
+    addClip(
+      { start: 0, end: duration, lane: baseLane, assetId },
+      { trackType: 'video', groupId },
+    )
+    addClip(
+      { start: 0, end: duration, lane: baseLane + 1, assetId },
+      { trackType: 'audio', groupId },
+    )
+  }
+}

--- a/apps/web/src/state/timelineStore.ts
+++ b/apps/web/src/state/timelineStore.ts
@@ -57,6 +57,7 @@ export interface TimelineState {
   updateClip: (id: string, delta: Partial<Omit<Clip, 'id'>>) => void
   updateTrack: (id: string, delta: Partial<Omit<Track, 'id'>>) => void
   removeClip: (id: string, opts?: { ripple?: boolean }) => void
+  removeClipsByAsset: (assetId: string) => void
   splitClipAt: (time: number) => string | null
   /** array of beat timestamps in seconds (monotonically increasing) */
   beats: number[]
@@ -255,6 +256,22 @@ export const useTimelineStore = create<TimelineState>((set) => ({
           )
         }
       })
+
+      const durationSec = Math.max(
+        0,
+        ...Object.values(clipsById).map((c) => c.end),
+      )
+
+      const tracks = pruneTracks(state.tracks, clipsById)
+      return { clipsById, durationSec, tracks }
+    }),
+
+  /** Remove all clips that reference the given asset id */
+  removeClipsByAsset: (assetId) =>
+    set((state) => {
+      const clipsById = Object.fromEntries(
+        Object.entries(state.clipsById).filter(([, c]) => c.assetId !== assetId),
+      )
 
       const durationSec = Math.max(
         0,


### PR DESCRIPTION
## Summary
- render list of imported assets with Add/Remove buttons
- add helper `insertAssetToTimeline` for dropping media assets
- simplify TrackRow drop handler to use util
- support removing all clips for a removed asset

## Testing
- `yarn lint` *(fails: 1338 errors)*
- `yarn test`