### PR TITLE
Implement lock and mute track logic

### DIFF
--- a/apps/web/src/features/preview/VideoPreview.tsx
+++ b/apps/web/src/features/preview/VideoPreview.tsx
@@ -14,6 +14,7 @@ import { useClipsArray } from '../timeline/hooks/useClipsArray'
  */
 export const VideoPreview: React.FC = React.memo(() => {
   const currentTime = useTimelineStore((s) => s.currentTime)
+  const tracks = useTimelineStore((s) => s.tracks)
   const playRate = useTransportStore((s) => s.playRate)
   const mediaAssets = useMotifStore((s) => s.mediaAssets)
   const clips = useClipsArray()
@@ -34,9 +35,9 @@ export const VideoPreview: React.FC = React.memo(() => {
   const sortedClips = React.useMemo(
     () =>
       clips
-        .filter((c) => c.lane % 2 === 0)
+        .filter((c) => c.lane % 2 === 0 && !tracks[c.lane]?.muted)
         .sort((a, b) => a.start - b.start),
-    [clips],
+    [clips, tracks],
   )
 
   // Determine active clip for the current time
@@ -46,6 +47,16 @@ export const VideoPreview: React.FC = React.memo(() => {
       null,
     [sortedClips, currentTime],
   )
+
+  React.useEffect(() => {
+    const video = videoRef.current
+    if (!video) return
+    if (!activeClip) {
+      video.pause()
+      video.removeAttribute('src')
+      video.load()
+    }
+  }, [activeClip])
 
   // Load the clip's media into the video element and render via GPU pipeline
   React.useEffect(() => {

--- a/apps/web/src/features/timeline/components/TrackRow.tsx
+++ b/apps/web/src/features/timeline/components/TrackRow.tsx
@@ -4,6 +4,7 @@ import { useTimelineStore } from '../../../state/timelineStore'
 import { Lock, Unlock, Eye, EyeOff, Volume2, VolumeX } from 'lucide-react'
 import { insertAssetToTimeline } from '../utils'
 import { InteractiveClip } from './InteractiveClip'
+import { Clip } from './Clip'
 
 /** Props for {@link TrackRow}. */
 interface TrackRowProps {
@@ -52,15 +53,24 @@ export const TrackRow: React.FC<TrackRowProps> = React.memo(({ laneIndex, clips,
 
   const renderedClips = React.useMemo(
     () =>
-      clips.map((clip) => (
-        <InteractiveClip
-          key={clip.id}
-          clip={clip}
-          pixelsPerSecond={pixelsPerSecond}
-          type={type}
-        />
-      )),
-    [clips, pixelsPerSecond, type],
+      clips.map((clip) =>
+        track.locked ? (
+          <Clip
+            key={clip.id}
+            clip={clip}
+            pixelsPerSecond={pixelsPerSecond}
+            type={type}
+          />
+        ) : (
+          <InteractiveClip
+            key={clip.id}
+            clip={clip}
+            pixelsPerSecond={pixelsPerSecond}
+            type={type}
+          />
+        ),
+      ),
+    [clips, pixelsPerSecond, type, track.locked],
   )
 
   const handleDragOver = React.useCallback((e: React.DragEvent<HTMLDivElement>) => {
@@ -107,7 +117,11 @@ export const TrackRow: React.FC<TrackRowProps> = React.memo(({ laneIndex, clips,
           <MuteIcon className="w-4 h-4" />
         </button>
       </div>
-      {renderedClips}
+      {track.locked ? (
+        <div className="pointer-events-none opacity-50">{renderedClips}</div>
+      ) : (
+        renderedClips
+      )}
     </div>
   )
 })

--- a/apps/web/src/state/timelineStore.ts
+++ b/apps/web/src/state/timelineStore.ts
@@ -169,6 +169,8 @@ export const useTimelineStore = create<TimelineState>((set) => ({
     set((state) => {
       const existing = state.clipsById[id]
       if (!existing) return {}
+      const track = state.tracks[existing.lane]
+      if (track?.locked) return {}
 
       const groupId = existing.groupId
       const startDiff =
@@ -229,6 +231,8 @@ export const useTimelineStore = create<TimelineState>((set) => ({
     set((state) => {
       const clip = state.clipsById[id]
       if (!clip) return {}
+      const track = state.tracks[clip.lane]
+      if (track?.locked) return {}
       const { ripple } = opts ?? {}
 
       const targetIds = Object.entries(state.clipsById)

--- a/apps/web/src/tests/components/TrackRow.test.tsx
+++ b/apps/web/src/tests/components/TrackRow.test.tsx
@@ -67,4 +67,35 @@ describe('TrackRow', () => {
     )
     expect(getByLabelText('Unlock track').className).toContain('opacity-50')
   })
+
+  it('renders clips disabled when track locked', () => {
+    const track: Track = {
+      id: 't1',
+      type: 'video',
+      label: 'V1',
+      groupId: 'g1',
+      locked: true,
+      muted: false,
+    }
+    const clip = { id: 'c1', start: 0, end: 1, lane: 0 }
+    act(() => {
+      useTimelineStore.setState({
+        clipsById: { [clip.id]: clip },
+        tracks: [track as never],
+        durationSec: 1,
+        currentTime: 0,
+        followPlayhead: true,
+        inPoint: null,
+        outPoint: null,
+        beats: [],
+        selectedClipIds: [],
+      })
+    })
+
+    const { container } = render(
+      <TrackRow laneIndex={0} clips={[clip]} pixelsPerSecond={100} track={track} />,
+    )
+
+    expect(container.querySelector('.pointer-events-none')).not.toBeNull()
+  })
 })

--- a/apps/web/src/tests/timeline/timelineStore.test.ts
+++ b/apps/web/src/tests/timeline/timelineStore.test.ts
@@ -100,4 +100,31 @@ describe('timelineStore', () => {
     expect(useTimelineStore.getState().clipsById[videoId]).toBeUndefined()
     expect(useTimelineStore.getState().clipsById[audioId]).toBeUndefined()
   })
+
+  it('updateClip is ignored when track locked', () => {
+    let id = ''
+    act(() => {
+      id = useTimelineStore.getState().addClip({ id: undefined as never, start: 0, end: 1, lane: 0 })
+    })
+    const trackId = useTimelineStore.getState().tracks[0].id
+    act(() => {
+      useTimelineStore.getState().updateTrack(trackId, { locked: true })
+      useTimelineStore.getState().updateClip(id, { start: 1 })
+    })
+    const clip = useTimelineStore.getState().clipsById[id]
+    expect(clip.start).toBe(0)
+  })
+
+  it('removeClip is ignored when track locked', () => {
+    let id = ''
+    act(() => {
+      id = useTimelineStore.getState().addClip({ id: undefined as never, start: 0, end: 1, lane: 0 })
+    })
+    const trackId = useTimelineStore.getState().tracks[0].id
+    act(() => {
+      useTimelineStore.getState().updateTrack(trackId, { locked: true })
+      useTimelineStore.getState().removeClip(id)
+    })
+    expect(useTimelineStore.getState().clipsById[id]).toBeDefined()
+  })
 })


### PR DESCRIPTION
## Summary
- disable clip interaction on locked tracks
- block updates/removals when track locked
- skip muted tracks in preview and clear frame when no active clip
- add tests for locked behavior

## Testing
- `yarn lint` *(fails: 1341 problems)*
- `yarn test`