### PR TITLE
Implement grouped A/V and multi-select dragging

### DIFF
--- a/apps/web/src/lib/store/index.ts
+++ b/apps/web/src/lib/store/index.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand'
 import type { MotifState, FileInfo, ClipSegment, BeatMarker, MediaAsset } from './types'
 
 import { generateId } from '../../utils/id'
+import { nanoid } from '../../utils/nanoid'
 import { useTimelineStore } from '../../state/timelineStore'
 
 // Create the store
@@ -105,8 +106,15 @@ const useMotifStore = create<MotifState>((set) => ({
     )
     const baseLane = maxLane + 1
     const duration = assetInput.metadata.duration ?? 0
-    timeline.addClip({ start: 0, end: duration, lane: baseLane, assetId: id })
-    timeline.addClip({ start: 0, end: duration, lane: baseLane + 1, assetId: id })
+    const groupId = nanoid()
+    timeline.addClip(
+      { start: 0, end: duration, lane: baseLane, assetId: id },
+      { trackType: 'video', groupId },
+    )
+    timeline.addClip(
+      { start: 0, end: duration, lane: baseLane + 1, assetId: id },
+      { trackType: 'audio', groupId },
+    )
   },
 
   /** Replace all media assets */


### PR DESCRIPTION
## Summary
- generate a groupId for paired clips when adding media assets
- allow dragging multiple selected clips horizontally
- prevent multi-select moves that would collide with other clips

## Testing
- `yarn lint` *(fails: 1381 errors)*
- `yarn test --run`