### PR TITLE
Implement WebAudio playback for timeline

### DIFF
--- a/apps/web/src/audioCtx.ts
+++ b/apps/web/src/audioCtx.ts
@@ -1,0 +1,7 @@
+let ctx: AudioContext | null = null
+if (typeof window !== 'undefined' && typeof AudioContext !== 'undefined') {
+  ctx = new AudioContext()
+}
+export const audioCtx = ctx
+export default audioCtx
+


### PR DESCRIPTION
## Summary
- add `audioCtx` singleton for WebAudio
- mix active audio tracks in `VideoPreview`

## Testing
- `yarn lint` *(fails: 1386 problems)*
- `yarn test`