### PR TITLE
Implement deselect on timeline background click

### DIFF
--- a/apps/web/src/features/timeline/components/Clip.tsx
+++ b/apps/web/src/features/timeline/components/Clip.tsx
@@ -105,7 +105,7 @@ export const Clip = React.memo(
         ref={localRef}
         // Container acts as `react-moveable` target. `group` enables hover state for handles.
         tabIndex={0}
-        className={`group absolute top-0 h-full select-none rounded-sm border border-white/10 ${colorClass} text-xs text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${isSelected ? 'ring-2 ring-accent' : ''}`}
+        className={`clip group absolute top-0 h-full select-none rounded-sm border border-white/10 ${colorClass} text-xs text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${isSelected ? 'ring-2 ring-accent' : ''}`}
         onPointerDown={handlePointerDown}
         style={{ width, transform: `translateX(${offset}px)`, willChange: 'transform', backgroundImage, backgroundSize: 'cover', backgroundPosition: 'center' }}
         aria-label={`Clip from ${clip.start.toFixed(2)}s to ${clip.end.toFixed(2)}s`}

--- a/apps/web/src/features/timeline/components/Timeline.tsx
+++ b/apps/web/src/features/timeline/components/Timeline.tsx
@@ -115,6 +115,17 @@ export const Timeline: React.FC<TimelineProps> = React.memo(({ pixelsPerSecond =
     [scrub, stopScrub],
   )
 
+  const handleBackgroundPointerDown = React.useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      const target = e.target as HTMLElement
+      if (!target.closest('.clip')) {
+        useTimelineStore.getState().setSelectedClips([])
+      }
+      startScrub(e)
+    },
+    [startScrub],
+  )
+
   // Track scroll position for playhead overlay
   const scrollRaf = React.useRef<number>()
   const handleScroll = React.useCallback(() => {
@@ -230,7 +241,7 @@ export const Timeline: React.FC<TimelineProps> = React.memo(({ pixelsPerSecond =
             <div
               ref={scrollRef}
               className="relative h-full overflow-x-scroll bg-panel-bg cursor-grab"
-              onPointerDown={startScrub}
+              onPointerDown={handleBackgroundPointerDown}
               onScroll={handleScroll}
             >
               <div className="relative h-full flex flex-col" style={{ width: duration * zoom }}>


### PR DESCRIPTION
## Summary
- add `.clip` class to clip elements
- clear selected clips when clicking empty space in the timeline

## Testing
- `yarn lint` *(fails: many existing lint errors)*
- `yarn test`
