### PR TITLE
Add drop-position handling for asset insertion

### DIFF
--- a/apps/web/src/features/timeline/components/Timeline.tsx
+++ b/apps/web/src/features/timeline/components/Timeline.tsx
@@ -179,6 +179,7 @@ export const Timeline: React.FC<TimelineProps> = React.memo(({ pixelsPerSecond =
           clips={laneMap.get(laneIndex) ?? []}
           pixelsPerSecond={zoom}
           track={track}
+          timelineRef={scrollRef}
         />
       )),
     [tracks, laneMap, zoom],

--- a/apps/web/src/features/timeline/utils.ts
+++ b/apps/web/src/features/timeline/utils.ts
@@ -2,7 +2,7 @@ import { nanoid } from '../../utils/nanoid'
 import { useMediaStore } from '../../state/mediaStore'
 import { useTimelineStore } from '../../state/timelineStore'
 
-export function insertAssetToTimeline(assetId: string) {
+export function insertAssetToTimeline(assetId: string, startSec?: number) {
   const { assets } = useMediaStore.getState()
   const asset = assets[assetId]
   if (!asset) return
@@ -13,23 +13,29 @@ export function insertAssetToTimeline(assetId: string) {
   const ext = asset.fileName.split('.').pop()?.toLowerCase() ?? ''
   const audioOnly = /^(mp3|wav|flac|ogg|aac|m4a)$/.test(ext)
   const duration = asset.duration
+  const start = startSec ?? 0
+  const end = start + duration
 
   let baseLane = tracks.length
   const groupId = nanoid()
 
   if (audioOnly) {
     addClip(
-      { start: 0, end: duration, lane: baseLane, assetId },
+      { start, end, lane: baseLane, assetId },
       { trackType: 'audio', groupId },
     )
   } else {
     addClip(
-      { start: 0, end: duration, lane: baseLane, assetId },
+      { start, end, lane: baseLane, assetId },
       { trackType: 'video', groupId },
     )
     addClip(
-      { start: 0, end: duration, lane: baseLane + 1, assetId },
+      { start, end, lane: baseLane + 1, assetId },
       { trackType: 'audio', groupId },
     )
   }
+
+  useTimelineStore.setState((s) => ({
+    durationSec: Math.max(s.durationSec, end),
+  }))
 }

--- a/apps/web/src/tests/components/TrackRow.test.tsx
+++ b/apps/web/src/tests/components/TrackRow.test.tsx
@@ -50,8 +50,15 @@ describe('TrackRow', () => {
       })
     })
 
+    const timelineRef = React.createRef<HTMLDivElement>()
     const { rerender, getByLabelText } = render(
-      <TrackRow laneIndex={0} clips={[]} pixelsPerSecond={100} track={track} />,
+      <TrackRow
+        laneIndex={0}
+        clips={[]}
+        pixelsPerSecond={100}
+        track={track}
+        timelineRef={timelineRef}
+      />,
     )
 
     const lockBtn = getByLabelText('Lock track') as HTMLButtonElement
@@ -63,7 +70,13 @@ describe('TrackRow', () => {
     expect(updated.locked).toBe(true)
 
     rerender(
-      <TrackRow laneIndex={0} clips={[]} pixelsPerSecond={100} track={updated} />,
+      <TrackRow
+        laneIndex={0}
+        clips={[]}
+        pixelsPerSecond={100}
+        track={updated}
+        timelineRef={timelineRef}
+      />,
     )
     expect(getByLabelText('Unlock track').className).toContain('opacity-50')
   })
@@ -92,8 +105,15 @@ describe('TrackRow', () => {
       })
     })
 
+    const timelineRef = React.createRef<HTMLDivElement>()
     const { container } = render(
-      <TrackRow laneIndex={0} clips={[clip]} pixelsPerSecond={100} track={track} />,
+      <TrackRow
+        laneIndex={0}
+        clips={[clip]}
+        pixelsPerSecond={100}
+        track={track}
+        timelineRef={timelineRef}
+      />,
     )
 
     expect(container.querySelector('.pointer-events-none')).not.toBeNull()


### PR DESCRIPTION
## Summary
- allow `TrackRow` drop handler to calculate drop time
- extend `insertAssetToTimeline` to accept optional start time
- track timeline element via `timelineRef` for drops
- update tests for new `TrackRow` prop

## Testing
- `yarn lint` *(fails: many existing lint errors)*
- `yarn test`