### PR TITLE
Implement align to beat for selected timeline clips

### DIFF
--- a/apps/web/src/features/timeline/components/AlignToBeatButton.tsx
+++ b/apps/web/src/features/timeline/components/AlignToBeatButton.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react'
+import { Button } from '../../../components/ui/Button'
+import { useTimelineStore } from '../../../state/timelineStore'
+import { getNearestBeat } from '../utils'
+
+export const AlignToBeatButton: React.FC = () => {
+  const beats = useTimelineStore((s) => s.beats)
+  const selectedIds = useTimelineStore((s) => s.selectedClipIds)
+
+  const handleAlign = React.useCallback(() => {
+    const { selectedClipIds, beats, updateClip, getClip, tracks } =
+      useTimelineStore.getState()
+    const processed = new Set<string>()
+    selectedClipIds.forEach((id) => {
+      const clip = getClip(id)
+      if (!clip) return
+      const track = tracks[clip.lane]
+      if (track?.locked) return
+      if (clip.groupId && processed.has(clip.groupId)) return
+      const nearest = getNearestBeat(clip.start, beats)
+      const delta = nearest - clip.start
+      updateClip(id, { start: nearest, end: clip.end + delta })
+      if (clip.groupId) processed.add(clip.groupId)
+    })
+  }, [])
+
+  const disabled = beats.length === 0 || selectedIds.length === 0
+
+  return (
+    <Button
+      variant="secondary"
+      className="px-2 py-1 text-xs"
+      onClick={handleAlign}
+      disabled={disabled}
+      title="Snap selected clips to nearest beat"
+    >
+      Align to Beat
+    </Button>
+  )
+}
+
+AlignToBeatButton.displayName = 'AlignToBeatButton'

--- a/apps/web/src/features/timeline/components/Timeline.tsx
+++ b/apps/web/src/features/timeline/components/Timeline.tsx
@@ -12,6 +12,7 @@ import { useClipsArray } from '../hooks/useClipsArray'
 import { useTimelineKeyboard } from '../hooks/useTimelineKeyboard'
 import { useZoomScroll } from '../hooks/useZoomScroll'
 import { ZoomSlider } from './ZoomSlider'
+import { AlignToBeatButton } from './AlignToBeatButton'
 import { Button } from '../../../components/ui/Button'
 import { PlayPauseButton } from './PlayPauseButton'
 
@@ -296,6 +297,7 @@ export const Timeline: React.FC<TimelineProps> = React.memo(({ pixelsPerSecond =
         <Button variant="secondary" className="px-2 py-1 text-xs" onClick={handleDelete}>
           Delete
         </Button>
+        <AlignToBeatButton />
         <Button variant="secondary" className="px-2 py-1 text-xs" onClick={() => setFollowPlayhead(!followPlayhead)}>
           {followPlayhead ? 'Unfollow' : 'Follow'}
         </Button>

--- a/apps/web/src/features/timeline/utils.ts
+++ b/apps/web/src/features/timeline/utils.ts
@@ -39,3 +39,14 @@ export function insertAssetToTimeline(assetId: string, startSec?: number) {
     durationSec: Math.max(s.durationSec, end),
   }))
 }
+
+/**
+ * Find the beat marker closest to the given time.
+ * Simple linear search as beat arrays are typically short.
+ */
+export function getNearestBeat(time: number, beats: number[]): number {
+  if (beats.length === 0) return time
+  return beats.reduce((prev, b) =>
+    Math.abs(b - time) < Math.abs(prev - time) ? b : prev,
+    beats[0])
+}

--- a/apps/web/src/state/timelineStore.ts
+++ b/apps/web/src/state/timelineStore.ts
@@ -62,6 +62,8 @@ export interface TimelineState {
   /** array of beat timestamps in seconds (monotonically increasing) */
   beats: number[]
   setBeats: (beats: number[]) => void
+  /** Retrieve a clip by id */
+  getClip: (id: string) => Clip | undefined
   setCurrentTime: (time: number) => void
   setInPoint: (time: number | null) => void
   setOutPoint: (time: number | null) => void
@@ -111,7 +113,7 @@ const pruneTracks = (
   return needed.slice(0, maxLane + 1)
 }
 
-export const useTimelineStore = create<TimelineState>((set) => ({
+export const useTimelineStore = create<TimelineState>((set, get) => ({
   clipsById: {},
   tracks: [],
   durationSec: 0,
@@ -143,6 +145,9 @@ export const useTimelineStore = create<TimelineState>((set) => ({
 
   /** Store beat timestamps in seconds */
   setBeats: (beats) => set({ beats }),
+
+  /** Retrieve a clip by id */
+  getClip: (id) => get().clipsById[id],
 
   /**
    * Add a new clip and return its generated id.


### PR DESCRIPTION
## Summary
- allow timeline store to retrieve clips
- provide utility to find the nearest beat
- add AlignToBeatButton next to existing timeline controls
- snap selected clips to closest beat markers

## Testing
- `yarn lint` *(fails: 1404 errors)*
- `yarn test`