### PR TITLE
Implement timeline panel with snapping toggle

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -6,7 +6,7 @@ import FileInfoCard from './features/import/FileInfoCard'
 import AnalyzeBeatsButton from './features/import/AnalyzeBeatsButton'
 import MediaLibrary from './features/import/MediaLibrary'
 import BeatMarkerBar from './features/timeline/BeatMarkerBar'
-import { Timeline } from './features/timeline/components/Timeline'
+import { TimelinePanel } from './features/timeline/TimelinePanel'
 import { CommandInput } from './features/timeline/components/CommandInput'
 import { VideoPreview } from './features/preview'
 import Panel from './components/Panel'
@@ -84,7 +84,7 @@ export default function App() {
               <ResizableHandle />
               <ResizablePanel defaultSize={100 - previewSize} minSize={20} className="timeline-area">
                 <Panel title="Timeline">
-                  <Timeline pixelsPerSecond={120} />
+                  <TimelinePanel pixelsPerSecond={120} />
                   <CommandInput />
                 </Panel>
               </ResizablePanel>

--- a/apps/web/src/features/timeline/TimelinePanel.tsx
+++ b/apps/web/src/features/timeline/TimelinePanel.tsx
@@ -1,0 +1,185 @@
+import * as React from 'react'
+import type { Clip } from '../../state/timelineStore'
+import { useTimelineStore } from '../../state/timelineStore'
+import { useTransportStore } from '../../state/transportStore'
+import { usePlaybackTicker } from '../../state/playbackTicker'
+import { useClipsArray } from './hooks/useClipsArray'
+import { useTimelineKeyboard } from './hooks/useTimelineKeyboard'
+import { useZoomScroll } from './hooks/useZoomScroll'
+import { TimeRuler } from './components/TimeRuler'
+import { TracksContainer } from './TracksContainer'
+import { TimelineToolbar } from './TimelineToolbar'
+
+interface TimelinePanelProps {
+  pixelsPerSecond?: number
+}
+
+export const TimelinePanel: React.FC<TimelinePanelProps> = React.memo(({ pixelsPerSecond = 100 }) => {
+  const [zoom, setZoom] = React.useState(pixelsPerSecond)
+  const scrollRef = React.useRef<HTMLDivElement>(null)
+  useZoomScroll(scrollRef, zoom, setZoom, { minZoom: 20, maxZoom: 500, zoomStep: 0.002 })
+  const [scrollLeft, setScrollLeft] = React.useState(0)
+
+  const clips = useClipsArray()
+  const tracks = useTimelineStore((s) => s.tracks)
+  const beats = useTimelineStore((s) => s.beats)
+
+  const playheadFrame = useTransportStore((s) => s.playheadFrame)
+  const playRate = useTransportStore((s) => s.playRate)
+  const playing = playRate !== 0
+  const setCurrentTime = useTimelineStore((s) => s.setCurrentTime)
+  const currentTime = useTimelineStore((s) => s.currentTime)
+  const followPlayhead = useTimelineStore((s) => s.followPlayhead)
+  const inPoint = useTimelineStore((s) => s.inPoint)
+  const outPoint = useTimelineStore((s) => s.outPoint)
+
+  const playheadSeconds = React.useMemo(() => playheadFrame / 30, [playheadFrame])
+  React.useEffect(() => {
+    setCurrentTime(playheadSeconds)
+  }, [playheadSeconds, setCurrentTime])
+
+  const laneMap = React.useMemo(() => {
+    const map = new Map<number, Clip[]>()
+    clips.forEach((clip) => {
+      const arr = map.get(clip.lane) ?? []
+      arr.push(clip)
+      map.set(clip.lane, arr)
+    })
+    return map
+  }, [clips])
+
+  const handleBackgroundPointerDown = React.useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      const target = e.target as HTMLElement
+      if (!target.closest('.clip')) {
+        useTimelineStore.getState().setSelectedClips([])
+      }
+      startScrub(e)
+    },
+    [],
+  )
+
+  // scrubbing logic
+  const scrubRef = React.useRef(false)
+  const scrub = React.useCallback(
+    (e: PointerEvent | React.PointerEvent) => {
+      if (!scrollRef.current) return
+      const rect = scrollRef.current.getBoundingClientRect()
+      const x = e.clientX - rect.left + scrollRef.current.scrollLeft
+      const time = x / zoom
+      setCurrentTime(Math.max(0, time))
+    },
+    [setCurrentTime, zoom],
+  )
+  const stopScrub = React.useCallback(() => {
+    if (!scrubRef.current) return
+    scrubRef.current = false
+    document.removeEventListener('pointermove', scrub)
+    document.removeEventListener('pointerup', stopScrub)
+  }, [scrub])
+  const startScrub = React.useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      if (e.button !== 0) return
+      scrubRef.current = true
+      scrub(e)
+      document.addEventListener('pointermove', scrub)
+      document.addEventListener('pointerup', stopScrub)
+    },
+    [scrub, stopScrub],
+  )
+
+  const handleScroll = React.useCallback(() => {
+    const el = scrollRef.current
+    if (!el) return
+    setScrollLeft(el.scrollLeft)
+  }, [])
+
+  React.useEffect(() => {
+    if (scrollRef.current) {
+      setScrollLeft(scrollRef.current.scrollLeft)
+    }
+  }, [])
+
+  const duration = React.useMemo(() => {
+    if (clips.length === 0) return 60
+    return clips.reduce((max, c) => Math.max(max, c.end), 0)
+  }, [clips])
+
+  React.useEffect(() => {
+    const el = scrollRef.current
+    if (!el || playRate === 0 || !followPlayhead) return
+    const x = currentTime * zoom
+    const start = el.scrollLeft
+    const end = start + el.clientWidth
+    const margin = 20
+    if (x < start + margin) {
+      el.scrollLeft = Math.max(0, x - margin)
+    } else if (x > end - margin) {
+      el.scrollLeft = x - el.clientWidth + margin
+    }
+  }, [currentTime, playRate, followPlayhead, zoom])
+
+  const [showZoomIndicator, setShowZoomIndicator] = React.useState(false)
+  const indicatorTimeout = React.useRef<number | null>(null)
+  React.useEffect(() => {
+    setShowZoomIndicator(true)
+    if (indicatorTimeout.current) clearTimeout(indicatorTimeout.current)
+    indicatorTimeout.current = window.setTimeout(() => {
+      setShowZoomIndicator(false)
+      indicatorTimeout.current = null
+    }, 800)
+  }, [zoom])
+
+  useTimelineKeyboard()
+  usePlaybackTicker()
+
+  return (
+    <div className="w-full select-none relative">
+      <div className="flex-1 overflow-hidden">
+        <TimeRuler scrollContainerRef={scrollRef} pixelsPerSecond={zoom} duration={duration} />
+        <div className="flex overflow-y-auto">
+          <div className="flex flex-col shrink-0">
+            <div className="h-6" />
+            {tracks.map((track) => {
+              const heightClass = track.type === 'video' ? 'h-12' : 'h-8'
+              return (
+                <div
+                  key={track.id}
+                  className={`${heightClass} flex items-center justify-center border-b border-white/10 text-xs text-gray-300 font-ui-medium`}
+                >
+                  {track.label}
+                </div>
+              )
+            })}
+          </div>
+          <TracksContainer
+            pixelsPerSecond={zoom}
+            scrollRef={scrollRef}
+            tracks={tracks}
+            laneMap={laneMap}
+            duration={duration}
+            beats={beats}
+            inPoint={inPoint}
+            outPoint={outPoint}
+            playheadSeconds={playheadSeconds}
+            playing={playing}
+            scrollLeft={scrollLeft}
+            onBackgroundPointerDown={handleBackgroundPointerDown}
+            onScrubStart={startScrub}
+            onScroll={handleScroll}
+          />
+        </div>
+      </div>
+      {showZoomIndicator && (
+        <div className="absolute top-2 right-2 bg-gray-800/80 px-2 py-1 rounded text-xs font-ui-medium">
+          {Math.round((zoom / pixelsPerSecond) * 100)}%
+        </div>
+      )}
+      <div className="absolute top-8 right-2">
+        <TimelineToolbar zoom={zoom} onZoomChange={setZoom} />
+      </div>
+    </div>
+  )
+})
+
+TimelinePanel.displayName = 'TimelinePanel'

--- a/apps/web/src/features/timeline/TimelineToolbar.tsx
+++ b/apps/web/src/features/timeline/TimelineToolbar.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react'
+import { PlayPauseButton } from './components/PlayPauseButton'
+import { ZoomSlider } from './components/ZoomSlider'
+import { Button } from '../../components/ui/Button'
+import { useTimelineStore } from '../../state/timelineStore'
+import { Scissors, Trash2, Magnet, Crosshair } from '../../stubs/lucide-react'
+
+interface TimelineToolbarProps {
+  zoom: number
+  onZoomChange: (z: number) => void
+}
+
+export const TimelineToolbar: React.FC<TimelineToolbarProps> = ({ zoom, onZoomChange }) => {
+  const splitClipAt = useTimelineStore((s) => s.splitClipAt)
+  const currentTime = useTimelineStore((s) => s.currentTime)
+  const removeClip = useTimelineStore((s) => s.removeClip)
+  const selected = useTimelineStore((s) => s.selectedClipIds)
+  const setSelected = useTimelineStore((s) => s.setSelectedClips)
+  const snapping = useTimelineStore((s) => s.snapping)
+  const setSnapping = useTimelineStore((s) => s.setSnapping)
+  const followPlayhead = useTimelineStore((s) => s.followPlayhead)
+  const setFollowPlayhead = useTimelineStore((s) => s.setFollowPlayhead)
+
+  const handleSplit = React.useCallback(() => splitClipAt(currentTime), [splitClipAt, currentTime])
+  const handleDelete = React.useCallback(() => {
+    selected.forEach((id) => removeClip(id))
+    if (selected.length > 0) setSelected([])
+  }, [removeClip, selected, setSelected])
+
+  return (
+    <div className="flex items-center space-x-2">
+      <PlayPauseButton />
+      <ZoomSlider value={zoom} onChange={onZoomChange} />
+      <Button variant="secondary" className="px-2 py-1" onClick={handleSplit}>
+        <Scissors className="w-4 h-4" />
+      </Button>
+      <Button variant="secondary" className="px-2 py-1" onClick={handleDelete}>
+        <Trash2 className="w-4 h-4" />
+      </Button>
+      <Button variant="secondary" className="px-2 py-1" onClick={() => setSnapping(!snapping)}>
+        <Magnet className="w-4 h-4" />
+      </Button>
+      <Button variant="secondary" className="px-2 py-1" onClick={() => setFollowPlayhead(!followPlayhead)}>
+        <Crosshair className="w-4 h-4" />
+      </Button>
+    </div>
+  )
+}
+
+TimelineToolbar.displayName = 'TimelineToolbar'

--- a/apps/web/src/features/timeline/TracksContainer.tsx
+++ b/apps/web/src/features/timeline/TracksContainer.tsx
@@ -1,0 +1,106 @@
+import * as React from 'react'
+import type { Clip, Track } from '../../state/timelineStore'
+import { Playhead } from './components/Playhead'
+import { TrackRow } from './components/TrackRow'
+
+interface TracksContainerProps {
+  pixelsPerSecond: number
+  scrollRef: React.RefObject<HTMLDivElement>
+  tracks: Track[]
+  laneMap: Map<number, Clip[]>
+  duration: number
+  beats: number[]
+  inPoint: number | null
+  outPoint: number | null
+  playheadSeconds: number
+  playing: boolean
+  scrollLeft: number
+  onBackgroundPointerDown: (e: React.PointerEvent<HTMLDivElement>) => void
+  onScrubStart: (e: React.PointerEvent<HTMLDivElement>) => void
+  onScroll: () => void
+}
+
+export const TracksContainer: React.FC<TracksContainerProps> = React.memo(
+  ({
+    pixelsPerSecond,
+    scrollRef,
+    tracks,
+    laneMap,
+    duration,
+    beats,
+    inPoint,
+    outPoint,
+    playheadSeconds,
+    playing,
+    scrollLeft,
+    onBackgroundPointerDown,
+    onScroll,
+  }) => {
+    const renderedTracks = React.useMemo(
+      () =>
+        tracks.map((track, laneIndex) => (
+          <TrackRow
+            key={track.id}
+            laneIndex={laneIndex}
+            clips={laneMap.get(laneIndex) ?? []}
+            pixelsPerSecond={pixelsPerSecond}
+            track={track}
+            timelineRef={scrollRef}
+          />
+        )),
+      [tracks, laneMap, pixelsPerSecond, scrollRef],
+    )
+
+    const trackAreaHeight = React.useMemo(
+      () => tracks.reduce((sum, t) => sum + (t.type === 'video' ? 48 : 32), 0),
+      [tracks],
+    )
+
+    return (
+      <div className="relative flex-1" style={{ minHeight: trackAreaHeight }}>
+        <div
+          ref={scrollRef}
+          className="relative h-full overflow-x-scroll bg-panel-bg cursor-grab"
+          onPointerDown={onBackgroundPointerDown}
+          onScroll={onScroll}
+        >
+          <div
+            className="relative h-full flex flex-col"
+            style={{ width: duration * pixelsPerSecond }}
+          >
+            {renderedTracks}
+            {beats.map((b) => (
+              <div
+                key={b}
+                className="absolute top-0 bottom-0 w-px bg-accent/20 pointer-events-none"
+                style={{ transform: `translateX(${b * pixelsPerSecond}px)` }}
+              />
+            ))}
+            {inPoint !== null && (
+              <div
+                className="absolute top-0 bottom-0 w-0.5 bg-green-400 pointer-events-none"
+                style={{ transform: `translateX(${inPoint * pixelsPerSecond}px)` }}
+              />
+            )}
+            {outPoint !== null && (
+              <div
+                className="absolute top-0 bottom-0 w-0.5 bg-red-400 pointer-events-none"
+                style={{ transform: `translateX(${outPoint * pixelsPerSecond}px)` }}
+              />
+            )}
+          </div>
+        </div>
+        <Playhead
+          positionSeconds={playheadSeconds}
+          pixelsPerSecond={pixelsPerSecond}
+          height="100%"
+          offsetX={scrollLeft}
+          onPointerDown={onScrubStart as any}
+          interactive={!playing}
+        />
+      </div>
+    )
+  },
+)
+
+TracksContainer.displayName = 'TracksContainer'

--- a/apps/web/src/features/timeline/components/InteractiveClip.tsx
+++ b/apps/web/src/features/timeline/components/InteractiveClip.tsx
@@ -39,6 +39,7 @@ export const InteractiveClip: React.FC<InteractiveClipProps> = React.memo(
         [clip.assetId],
       ),
     )
+    const snapping = useTimelineStore((s) => s.snapping)
     const ref = React.useRef<HTMLDivElement>(null)
 
     // ------------------------------------------------------------------------
@@ -167,7 +168,7 @@ export const InteractiveClip: React.FC<InteractiveClipProps> = React.memo(
       // --- horizontal movement / snapping ----------------------------------
       let newStart =
         origin.current.startSec + translateX / pixelsPerSecond
-      const snap = findSnap(newStart)
+      const snap = snapping ? findSnap(newStart) : null
       if (snap !== null) {
         newStart = snap
         translateXRef.current =
@@ -331,7 +332,7 @@ export const InteractiveClip: React.FC<InteractiveClipProps> = React.memo(
           newStart,
           origin.current.endSec - maxDuration,
         )
-        const snap = findSnap(newStart)
+        const snap = snapping ? findSnap(newStart) : null
         if (snap !== null) {
           newStart = snap
           newWidthPx =
@@ -362,7 +363,7 @@ export const InteractiveClip: React.FC<InteractiveClipProps> = React.memo(
           newEnd,
           origin.current.startSec + maxDuration,
         )
-        const snap = findSnap(newEnd)
+        const snap = snapping ? findSnap(newEnd) : null
         if (snap !== null) {
           newEnd = snap
           newWidthPx =

--- a/apps/web/src/features/timeline/index.ts
+++ b/apps/web/src/features/timeline/index.ts
@@ -1,3 +1,3 @@
-export { Timeline } from './components/Timeline'
+export { TimelinePanel } from './TimelinePanel'
 export { useBeatSlices } from './hooks/useBeatSlices'
-export * from './hooks/useTimelineKeyboard' 
+export * from './hooks/useTimelineKeyboard'

--- a/apps/web/src/state/timelineStore.ts
+++ b/apps/web/src/state/timelineStore.ts
@@ -43,6 +43,8 @@ export interface TimelineState {
   currentTime: number
   /** Auto-scroll timeline to keep playhead in view */
   followPlayhead: boolean
+  /** Enable snap-to references when dragging clips */
+  snapping: boolean
   /** Ids of currently selected clips */
   selectedClipIds: string[]
   /** Optional in/out points in seconds */
@@ -68,6 +70,7 @@ export interface TimelineState {
   setInPoint: (time: number | null) => void
   setOutPoint: (time: number | null) => void
   setFollowPlayhead: (follow: boolean) => void
+  setSnapping: (value: boolean) => void
   setSelectedClips: (ids: string[]) => void
 }
 
@@ -122,6 +125,7 @@ export const useTimelineStore = create<TimelineState>((set, get) => ({
   outPoint: null,
   beats: [],
   followPlayhead: true,
+  snapping: true,
   selectedClipIds: [],
 
   /**
@@ -320,6 +324,8 @@ export const useTimelineStore = create<TimelineState>((set, get) => ({
   setOutPoint: (time) => set({ outPoint: time }),
   /** Enable or disable auto-follow behavior */
   setFollowPlayhead: (follow) => set({ followPlayhead: follow }),
+  /** Toggle snapping during clip edits */
+  setSnapping: (value) => set({ snapping: value }),
   /** Replace current selection */
   setSelectedClips: (ids) => set({ selectedClipIds: ids }),
 }))

--- a/apps/web/src/stubs/lucide-react.tsx
+++ b/apps/web/src/stubs/lucide-react.tsx
@@ -55,3 +55,52 @@ export const VolumeX = (props: React.SVGProps<SVGSVGElement>) => (
 )
 
 // TODO(tauri-port): replace with real lucide-react once network install allowed
+export const Play = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 24 24" {...iconProps} {...props}>
+    <polygon points="5 3 19 12 5 21 5 3" />
+  </svg>
+)
+
+export const Pause = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 24 24" {...iconProps} {...props}>
+    <rect x="6" y="4" width="4" height="16" />
+    <rect x="14" y="4" width="4" height="16" />
+  </svg>
+)
+
+export const Scissors = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 24 24" {...iconProps} {...props}>
+    <circle cx="6" cy="6" r="3" />
+    <circle cx="6" cy="18" r="3" />
+    <line x1="20" y1="4" x2="8" y2="16" />
+    <line x1="8" y1="8" x2="20" y2="20" />
+  </svg>
+)
+
+export const Trash2 = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 24 24" {...iconProps} {...props}>
+    <polyline points="3 6 5 6 21 6" />
+    <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6" />
+    <path d="M10 11v6" />
+    <path d="M14 11v6" />
+    <rect x="9" y="2" width="6" height="4" />
+  </svg>
+)
+
+export const Magnet = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 24 24" {...iconProps} {...props}>
+    <path d="M4 15v-3a8 8 0 0 1 16 0v3" />
+    <line x1="4" y1="15" x2="4" y2="21" />
+    <line x1="20" y1="15" x2="20" y2="21" />
+  </svg>
+)
+
+export const Crosshair = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 24 24" {...iconProps} {...props}>
+    <circle cx="12" cy="12" r="10" />
+    <line x1="12" y1="2" x2="12" y2="6" />
+    <line x1="12" y1="18" x2="12" y2="22" />
+    <line x1="2" y1="12" x2="6" y2="12" />
+    <line x1="18" y1="12" x2="22" y2="12" />
+  </svg>
+)


### PR DESCRIPTION
## Summary
- add stub icons for timeline toolbar
- support `snapping` state in timeline store
- respect snapping setting in `InteractiveClip`
- create `TracksContainer`, `TimelineToolbar`, and `TimelinePanel`
- wire up new panel in app

## Testing
- `yarn lint` *(fails: 1409 errors)*
- `yarn test`