### PR TITLE
Add inspector panel with editable clip properties

### DIFF
--- a/apps/web/src/components/ui/Input.tsx
+++ b/apps/web/src/components/ui/Input.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react'
+
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  className?: string
+}
+
+export const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className = '', ...props }, ref) => (
+    <input
+      ref={ref}
+      className={`h-7 rounded border border-gray-700 bg-gray-800 px-1 text-sm text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent ${className}`}
+      {...props}
+    />
+  ),
+)
+
+Input.displayName = 'Input'

--- a/apps/web/src/components/ui/Switch.tsx
+++ b/apps/web/src/components/ui/Switch.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react'
+
+export interface SwitchProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  className?: string
+}
+
+export const Switch = React.forwardRef<HTMLInputElement, SwitchProps>(
+  ({ className = '', ...props }, ref) => (
+    <input
+      ref={ref}
+      type="checkbox"
+      className={`accent-accent w-4 h-4 ${className}`}
+      {...props}
+    />
+  ),
+)
+
+Switch.displayName = 'Switch'

--- a/apps/web/src/features/inspector/InspectorPanel.tsx
+++ b/apps/web/src/features/inspector/InspectorPanel.tsx
@@ -1,3 +1,107 @@
+import * as React from 'react'
+import { useSelectionStore } from '../../state/selectionStore'
+import { useTimelineStore } from '../../state/timelineStore'
+import { useMediaStore } from '../../state/mediaStore'
+import { Slider } from '../../components/ui/Slider'
+import { Input } from '../../components/ui/Input'
+import { Switch } from '../../components/ui/Switch'
+
 export default function InspectorPanel() {
-  return <div className="text-ui-body text-gray-300 p-2">Inspector Panel</div>
+  const selection = useSelectionStore((s) => s.currentSelection)
+
+  const clip = useTimelineStore(
+    React.useCallback(
+      (s) => (selection?.type === 'clip' ? s.clipsById[selection.id] : null),
+      [selection],
+    ),
+  )
+  const asset = useMediaStore(
+    React.useCallback(
+      (s) => (selection?.type === 'asset' ? s.assets[selection.id] : null),
+      [selection],
+    ),
+  )
+  const updateClip = useTimelineStore((s) => s.updateClip)
+
+  if (!selection) {
+    return <div className="text-ui-body text-gray-300">Select a clip to edit properties</div>
+  }
+
+  if (selection.type === 'asset' && asset) {
+    return (
+      <div className="text-ui-body text-gray-300 space-y-2">
+        <div className="font-ui-medium text-accent">Asset</div>
+        <div>{asset.fileName}</div>
+        <div>Duration: {asset.duration.toFixed(2)}s</div>
+      </div>
+    )
+  }
+
+  if (!clip) {
+    return <div className="text-ui-body text-gray-300">Select a clip to edit properties</div>
+  }
+
+  const [x, setX] = React.useState(clip.x)
+  const [y, setY] = React.useState(clip.y)
+  const [scale, setScale] = React.useState(clip.scale)
+  const [rotation, setRotation] = React.useState(clip.rotation)
+  const [volume, setVolume] = React.useState(clip.volume)
+  const [muted, setMuted] = React.useState(clip.muted)
+
+  React.useEffect(() => {
+    setX(clip.x)
+    setY(clip.y)
+    setScale(clip.scale)
+    setRotation(clip.rotation)
+    setVolume(clip.volume)
+    setMuted(clip.muted)
+  }, [clip])
+
+  React.useEffect(() => {
+    const t = setTimeout(() => {
+      updateClip(clip.id, { x, y, scale, rotation, volume, muted })
+    }, 100)
+    return () => clearTimeout(t)
+  }, [clip.id, x, y, scale, rotation, volume, muted, updateClip])
+
+  return (
+    <div className="text-ui-body text-gray-300 space-y-4">
+      <section>
+        <h3 className="font-ui-medium text-accent mb-1">Transform</h3>
+        <div className="space-y-2">
+          <label className="flex items-center gap-2">
+            <span className="w-12">X</span>
+            <Input type="number" value={x} onChange={(e) => setX(parseFloat(e.target.value))} />
+          </label>
+          <label className="flex items-center gap-2">
+            <span className="w-12">Y</span>
+            <Input type="number" value={y} onChange={(e) => setY(parseFloat(e.target.value))} />
+          </label>
+          <label className="flex items-center gap-2">
+            <span className="w-12">Scale</span>
+            <Input type="number" step="0.1" value={scale} onChange={(e) => setScale(parseFloat(e.target.value))} />
+          </label>
+          <label className="flex items-center gap-2">
+            <span className="w-12">Rotation</span>
+            <Input type="number" value={rotation} onChange={(e) => setRotation(parseFloat(e.target.value))} />
+          </label>
+        </div>
+      </section>
+      <section>
+        <h3 className="font-ui-medium text-accent mb-1">Audio</h3>
+        <label className="flex items-center gap-2">
+          <span className="w-12">Volume</span>
+          <Slider value={[volume * 100]} onValueChange={(v) => setVolume(v[0] / 100)} min={0} max={100} />
+        </label>
+        <label className="flex items-center gap-2">
+          <span className="w-12">Mute</span>
+          <Switch checked={muted} onChange={(e) => setMuted(e.target.checked)} />
+        </label>
+      </section>
+      <section>
+        <h3 className="font-ui-medium text-accent mb-1">Effects</h3>
+        <div className="text-xs text-gray-400">No effects</div>
+      </section>
+    </div>
+  )
 }

--- a/apps/web/src/features/library/AssetCard.tsx
+++ b/apps/web/src/features/library/AssetCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import type { MediaAsset } from '../../state/mediaStore'
+import { useSelectionStore } from '../../state/selectionStore'
 
 interface AssetCardProps {
   asset: MediaAsset
@@ -20,6 +21,9 @@ export function AssetCard({ asset }: AssetCardProps) {
       className="w-20 text-center text-xs select-none"
       draggable
       onDragStart={handleDragStart}
+      onClick={() =>
+        useSelectionStore.getState().setSelection({ type: 'asset', id: asset.id })
+      }
     >
       {isVideo ? (
         <img

--- a/apps/web/src/features/timeline/components/Clip.tsx
+++ b/apps/web/src/features/timeline/components/Clip.tsx
@@ -3,6 +3,7 @@ import * as React from 'react'
 import type { Clip as ClipType } from '../../../state/timelineStore'
 import { useMediaStore } from '../../../state/mediaStore'
 import { useTimelineStore } from '../../../state/timelineStore'
+import { useSelectionStore } from '../../../state/selectionStore'
 
 /** Props for {@link Clip}. */
 interface ClipProps {
@@ -87,6 +88,7 @@ export const Clip = React.memo(
     const handlePointerDown = React.useCallback(
       (e: React.PointerEvent) => {
         e.stopPropagation()
+        useSelectionStore.getState().setSelection({ type: 'clip', id: clip.id })
         if (e.shiftKey || e.metaKey || e.ctrlKey) {
           if (isSelected) {
             setSelected(selectedIds.filter((id) => id !== clip.id))

--- a/apps/web/src/state/selectionStore.ts
+++ b/apps/web/src/state/selectionStore.ts
@@ -1,0 +1,16 @@
+import { create } from 'zustand'
+
+export type Selection =
+  | { type: 'clip'; id: string }
+  | { type: 'asset'; id: string }
+  | null
+
+interface SelectionState {
+  currentSelection: Selection
+  setSelection: (s: Selection) => void
+}
+
+export const useSelectionStore = create<SelectionState>((set) => ({
+  currentSelection: null,
+  setSelection: (s) => set({ currentSelection: s }),
+}))

--- a/apps/web/src/state/timelineStore.ts
+++ b/apps/web/src/state/timelineStore.ts
@@ -16,6 +16,18 @@ export interface Clip {
   assetId?: string
   /** identifier grouping paired audio/video clips */
   groupId?: string
+  /** horizontal position within preview canvas */
+  x: number
+  /** vertical position within preview canvas */
+  y: number
+  /** scale multiplier */
+  scale: number
+  /** rotation in degrees */
+  rotation: number
+  /** audio volume (0-1) */
+  volume: number
+  /** mute audio */
+  muted: boolean
 }
 
 export interface Track {
@@ -159,7 +171,17 @@ export const useTimelineStore = create<TimelineState>((set, get) => ({
    */
   addClip: (clipInput, opts) => {
     const id = generateId()
-    const newClip: Clip = { ...clipInput, id, groupId: opts?.groupId }
+    const newClip: Clip = {
+      x: 0,
+      y: 0,
+      scale: 1,
+      rotation: 0,
+      volume: 1,
+      muted: false,
+      ...clipInput,
+      id,
+      groupId: opts?.groupId,
+    }
     set((state) => {
       const clipsById = { ...state.clipsById, [id]: newClip }
       const durationSec = Math.max(state.durationSec, newClip.end)
@@ -186,6 +208,11 @@ export const useTimelineStore = create<TimelineState>((set, get) => ({
         delta.start !== undefined ? delta.start - existing.start : 0
       const endDiff = delta.end !== undefined ? delta.end - existing.end : 0
       const laneDiff = delta.lane !== undefined ? delta.lane - existing.lane : 0
+      const xDiff = delta.x !== undefined ? delta.x - existing.x : 0
+      const yDiff = delta.y !== undefined ? delta.y - existing.y : 0
+      const scaleDiff = delta.scale !== undefined ? delta.scale - existing.scale : 0
+      const rotDiff = delta.rotation !== undefined ? delta.rotation - existing.rotation : 0
+      const volDiff = delta.volume !== undefined ? delta.volume - existing.volume : 0
 
       const clipsById = { ...state.clipsById }
 
@@ -195,6 +222,12 @@ export const useTimelineStore = create<TimelineState>((set, get) => ({
           ...(delta.start !== undefined && { start: clip.start + startDiff }),
           ...(delta.end !== undefined && { end: clip.end + endDiff }),
           ...(delta.lane !== undefined && { lane: clip.lane + laneDiff }),
+          ...(delta.x !== undefined && { x: clip.x + xDiff }),
+          ...(delta.y !== undefined && { y: clip.y + yDiff }),
+          ...(delta.scale !== undefined && { scale: clip.scale + scaleDiff }),
+          ...(delta.rotation !== undefined && { rotation: clip.rotation + rotDiff }),
+          ...(delta.volume !== undefined && { volume: clip.volume + volDiff }),
+          ...(delta.muted !== undefined && { muted: delta.muted }),
         }
         clipsById[cid] = upd
       }


### PR DESCRIPTION
## Summary
- create generic `Input` and `Switch` UI controls
- track current clip/asset via `selectionStore`
- extend `timelineStore` clip model with transform and audio props
- wire selection events in `Clip` and `AssetCard`
- implement `InspectorPanel` with transform and audio controls

## Testing
- `yarn lint` *(fails: 1453 problems)*
- `yarn test`