### PR TITLE
Implement dark theme tokens and UI polish

### DIFF
--- a/apps/web/src/components/Panel.tsx
+++ b/apps/web/src/components/Panel.tsx
@@ -10,8 +10,8 @@ interface PanelProps {
 export default function Panel({ title, onCollapse, children, className }: PanelProps) {
   return (
     <div className={`flex flex-col h-full ${className ?? ''}`.trim()}>
-      <div className="flex items-center justify-between px-2 py-1 bg-gray-800 border-b border-gray-700">
-        <span className="text-ui-body font-ui-medium">{title}</span>
+      <div className="flex items-center justify-between px-2 py-2 bg-panel-bg-secondary border-b border-panel-bg">
+        <span className="text-ui-body font-ui-semibold">{title}</span>
         {onCollapse && (
           <button type="button" onClick={onCollapse} className="text-xs hover:text-accent">
             &laquo;
@@ -22,3 +22,4 @@ export default function Panel({ title, onCollapse, children, className }: PanelP
     </div>
   )
 }
+

--- a/apps/web/src/components/Toast.tsx
+++ b/apps/web/src/components/Toast.tsx
@@ -6,6 +6,7 @@ interface Toast {
 }
 
 const ToastContext = React.createContext<(msg: string) => void>(() => {})
+let globalToast: ((msg: string) => void) | null = null
 
 export const ToastProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [toasts, setToasts] = React.useState<Toast[]>([])
@@ -18,18 +19,30 @@ export const ToastProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     }, 3000)
   }, [])
 
+  React.useEffect(() => {
+    globalToast = addToast
+    return () => {
+      if (globalToast === addToast) globalToast = null
+    }
+  }, [addToast])
+
   return (
     <ToastContext.Provider value={addToast}>
       {children}
-      <div className="fixed bottom-4 left-1/2 -translate-x-1/2 space-y-2 z-50">
-        {toasts.map((t) => (
-          <div key={t.id} className="bg-gray-800 text-white px-3 py-2 rounded shadow">
-            {t.message}
-          </div>
-        ))}
-      </div>
+        <div className="fixed bottom-4 left-1/2 -translate-x-1/2 space-y-2 z-50">
+          {toasts.map((t) => (
+            <div key={t.id} className="bg-panel-bg-secondary text-text-primary px-4 py-2 rounded-md shadow">
+              {t.message}
+            </div>
+          ))}
+        </div>
     </ToastContext.Provider>
   )
 }
 
 export const useToast = () => React.useContext(ToastContext)
+export const toast = (msg: string) => {
+  globalToast?.(msg)
+}
+
+

--- a/apps/web/src/components/ui/Button.tsx
+++ b/apps/web/src/components/ui/Button.tsx
@@ -2,13 +2,14 @@ import * as React from 'react'
 import { Slot } from '@radix-ui/react-slot'
 
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  variant?: 'default' | 'secondary'
+  variant?: 'default' | 'secondary' | 'destructive'
   asChild?: boolean
 }
 
 const variantClasses: Record<NonNullable<ButtonProps['variant']>, string> = {
   default: 'bg-accent text-white hover:bg-accent/90',
-  secondary: 'bg-gray-700 text-white hover:bg-gray-600',
+  secondary: 'bg-panel-bg-secondary text-text-primary hover:bg-panel-bg',
+  destructive: 'bg-red-600 text-white hover:bg-red-700',
 }
 
 export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(({ className = '', variant = 'default', asChild = false, ...props }, ref) => {
@@ -16,7 +17,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(({ classN
   return (
     <Comp
       ref={ref}
-      className={`inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 ${variantClasses[variant]} ${className}`}
+      className={`inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-40 ${variantClasses[variant]} ${className}`}
       {...(props as any)}
     />
   )

--- a/apps/web/src/components/ui/Input.tsx
+++ b/apps/web/src/components/ui/Input.tsx
@@ -8,10 +8,11 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
   ({ className = '', ...props }, ref) => (
     <input
       ref={ref}
-      className={`h-7 rounded border border-gray-700 bg-gray-800 px-1 text-sm text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent ${className}`}
+      className={`h-8 rounded-md border border-panel-bg-secondary bg-panel-bg px-2 text-sm text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent disabled:opacity-40 ${className}`}
       {...props}
     />
   ),
 )
 
 Input.displayName = 'Input'
+

--- a/apps/web/src/components/ui/Slider.tsx
+++ b/apps/web/src/components/ui/Slider.tsx
@@ -14,10 +14,10 @@ export const Slider = React.forwardRef<HTMLSpanElement, SliderProps>(
   ({ className = '', ...props }, ref) => (
     <RadixSlider.Root
       ref={ref}
-      className={`relative flex items-center select-none touch-none w-full h-5 ${className}`}
+      className={`relative flex items-center select-none touch-none w-full h-6 ${className}`}
       {...props}
     >
-      <RadixSlider.Track className="bg-gray-700 relative grow rounded-full h-1">
+      <RadixSlider.Track className="bg-panel-bg-secondary relative grow rounded-full h-1">
         <RadixSlider.Range className="absolute bg-accent rounded-full h-full" />
       </RadixSlider.Track>
       <RadixSlider.Thumb

--- a/apps/web/src/components/ui/Tooltip.tsx
+++ b/apps/web/src/components/ui/Tooltip.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react'
+
+interface TooltipProps {
+  content: React.ReactNode
+  children: React.ReactNode
+}
+
+export function Tooltip({ content, children }: TooltipProps) {
+  return (
+    <span className="relative group inline-flex">
+      {children}
+      <span className="pointer-events-none absolute bottom-full left-1/2 mb-1 w-max -translate-x-1/2 rounded bg-panel-bg-secondary px-2 py-1 text-text-secondary text-ui-caption opacity-0 transition-opacity group-hover:opacity-100">
+        {content}
+      </span>
+    </span>
+  )
+}
+

--- a/apps/web/src/export/segment.ts
+++ b/apps/web/src/export/segment.ts
@@ -108,6 +108,7 @@ import { useTimelineStore } from '../state/timelineStore'
 import { useTransportStore } from '../state/transportStore'
 import useMotifStore from '../lib/store'
 import { audioCtx } from '../audioCtx'
+import { toast } from '../components/Toast'
 
 /**
  * Export the timeline preview + audio to a WebM file via MediaRecorder.
@@ -183,6 +184,7 @@ export const exportTimelineVideo = async (): Promise<void> => {
   URL.revokeObjectURL(url)
 
   setExportStatus(false, 1, null)
+  toast('Export complete')
 }
 export interface SegmentRange {
   start: number

--- a/apps/web/src/features/import/FileInfoCard.tsx
+++ b/apps/web/src/features/import/FileInfoCard.tsx
@@ -21,7 +21,7 @@ export default function FileInfoCard() {
   }
 
   return (
-    <div className="p-4 rounded-lg bg-gray-800 text-white space-y-2">
+    <div className="p-4 rounded-lg bg-panel-bg-secondary text-text-primary space-y-2">
       <h3 className="text-ui-body font-ui-medium text-accent">Imported File</h3>
       <div className="text-ui-body font-ui-normal flex flex-col space-y-1">
         <div>

--- a/apps/web/src/features/import/MediaIngest.tsx
+++ b/apps/web/src/features/import/MediaIngest.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useState } from 'react'
+import { useToast } from '../../components/Toast'
 import useMotifStore from '../../lib/store'
 import { extractVideoMetadata } from '../../lib/file/extractVideoMetadata'
 import type { VideoMetadata } from '../../lib/file/extractVideoMetadata'
@@ -21,6 +22,7 @@ export default function MediaIngest() {
   const setFileInfo = useMotifStore((s) => s.setFileInfo)
   const setFileError = useMotifStore((s) => s.setFileError)
   const [loading, setLoading] = useState(false)
+  const toast = useToast()
 
   const handleFileHandles = useCallback(async (handles: FileSystemFileHandle[]) => {
     setLoading(true)
@@ -66,11 +68,13 @@ export default function MediaIngest() {
         } catch (err) {
           console.error('Error importing file:', err)
           setFileError('Failed to import file.')
+          toast('Failed to import file.')
         }
       }),
     )
     setLoading(false)
-  }, [addMediaAsset, setFileInfo, setFileError])
+    toast('Import complete')
+  }, [addMediaAsset, setFileInfo, setFileError, toast])
 
   const openPicker = async () => {
     try {

--- a/apps/web/src/features/shell/CommandPalette.tsx
+++ b/apps/web/src/features/shell/CommandPalette.tsx
@@ -111,12 +111,12 @@ export function CommandPalette() {
       onClick={() => setOpen(false)}
     >
       <div
-        className="bg-gray-800 w-96 rounded shadow"
+        className="bg-panel-bg-secondary w-96 rounded-md shadow"
         onClick={(e) => e.stopPropagation()}
       >
         <input
           ref={inputRef}
-          className="w-full bg-gray-700 text-white px-3 py-2 outline-none"
+          className="w-full bg-panel-bg text-text-primary px-3 py-2 outline-none"
           placeholder="Type a command or ask AI..."
           value={query}
           onChange={(e) => {

--- a/apps/web/src/features/shell/MainToolbar.tsx
+++ b/apps/web/src/features/shell/MainToolbar.tsx
@@ -26,7 +26,7 @@ export const MainToolbar: React.FC = () => {
   const handleSplit = React.useCallback(() => splitClipAt(currentTime), [splitClipAt, currentTime])
 
   return (
-    <div className="toolbar bg-gray-800 px-2 py-1 flex items-center space-x-1">
+    <div className="toolbar bg-panel-bg-secondary px-2 py-1 flex items-center space-x-1">
       <Button
         variant="secondary"
         className="toolbar-button"

--- a/apps/web/src/features/shell/SettingsModal.tsx
+++ b/apps/web/src/features/shell/SettingsModal.tsx
@@ -11,7 +11,7 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
 
   return (
     <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 fade-in show">
-      <div className="bg-gray-800 rounded-md p-6 w-80">
+      <div className="bg-panel-bg-secondary rounded-md p-6 w-80">
         <h2 className="text-ui-heading font-ui-semibold mb-4">Settings</h2>
         <div className="space-y-2 text-ui-body">
           <label className="flex items-center gap-2">

--- a/apps/web/src/features/timeline/TimelinePanel.tsx
+++ b/apps/web/src/features/timeline/TimelinePanel.tsx
@@ -177,7 +177,7 @@ export const TimelinePanel: React.FC<TimelinePanelProps> = React.memo(({ pixelsP
         </div>
       </div>
       {showZoomIndicator && (
-        <div className="absolute top-2 right-2 bg-gray-800/80 px-2 py-1 rounded text-xs font-ui-medium">
+        <div className="absolute top-2 right-2 bg-panel-bg-secondary/80 px-2 py-1 rounded text-xs font-ui-medium">
           {Math.round((zoom / pixelsPerSecond) * 100)}%
         </div>
       )}
@@ -189,3 +189,4 @@ export const TimelinePanel: React.FC<TimelinePanelProps> = React.memo(({ pixelsP
 })
 
 TimelinePanel.displayName = 'TimelinePanel'
+

--- a/apps/web/src/features/timeline/components/Clip.tsx
+++ b/apps/web/src/features/timeline/components/Clip.tsx
@@ -107,7 +107,7 @@ export const Clip = React.memo(
         ref={localRef}
         // Container acts as `react-moveable` target. `group` enables hover state for handles.
         tabIndex={0}
-        className={`clip group absolute top-0 h-full select-none rounded-sm border border-white/10 ${colorClass} text-xs text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${isSelected ? 'ring-2 ring-accent' : ''}`}
+        className={`clip group absolute top-0 h-full select-none rounded-sm border border-white/10 ${colorClass} text-xs text-white hover:border-accent/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${isSelected ? 'ring-2 ring-accent' : ''}`}
         onPointerDown={handlePointerDown}
         style={{ width, transform: `translateX(${offset}px)`, willChange: 'transform', backgroundImage, backgroundSize: 'cover', backgroundPosition: 'center' }}
         aria-label={`Clip from ${clip.start.toFixed(2)}s to ${clip.end.toFixed(2)}s`}

--- a/apps/web/src/features/timeline/components/Timeline.tsx
+++ b/apps/web/src/features/timeline/components/Timeline.tsx
@@ -283,7 +283,7 @@ export const Timeline: React.FC<TimelineProps> = React.memo(({ pixelsPerSecond =
       </div>
       {/* Zoom level indicator */}
       {showZoomIndicator && (
-        <div className="absolute top-2 right-2 bg-gray-800/80 px-2 py-1 rounded text-xs font-ui-medium">
+        <div className="absolute top-2 right-2 bg-panel-bg-secondary/80 px-2 py-1 rounded text-xs font-ui-medium">
           {Math.round((zoom / initialZoom.current) * 100)}%
         </div>
       )}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -5,6 +5,18 @@
 @tailwind components;
 @tailwind utilities;
 
+:root {
+  --panel-bg: #101012;
+  --panel-bg-secondary: #18181b;
+  --accent: #4e8cff;
+  --text-primary: #ffffff;
+  --text-secondary: #cbd5e1;
+}
+
+body {
+  @apply bg-panel-bg text-text-primary font-sans text-ui-body;
+}
+
 /* Fade keyframes (150ms default) */
 @layer utilities {
   .fade-in {

--- a/apps/web/src/styles/tokens.js
+++ b/apps/web/src/styles/tokens.js
@@ -1,6 +1,9 @@
 export const colors = {
-  panelBg: '#101012',
-  accent: '#4E8CFF',
+  panelBg: 'var(--panel-bg)',
+  panelBgSecondary: 'var(--panel-bg-secondary)',
+  accent: 'var(--accent)',
+  textPrimary: 'var(--text-primary)',
+  textSecondary: 'var(--text-secondary)',
   clipVideo: 'rgba(30,144,255,.5)',
   clipAudio: 'rgba(255,64,128,.5)',
 }
@@ -11,6 +14,7 @@ export const fonts = {
   },
   size: {
     uiLabel: '11px',
+    uiCaption: '12px',
     uiBody: '14px',
     uiHeading: '24px',
   },

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -18,7 +18,10 @@ export default {
     extend: {
       colors: {
         'panel-bg': colors.panelBg,
+        'panel-bg-secondary': colors.panelBgSecondary,
         accent: colors.accent,
+        'text-primary': colors.textPrimary,
+        'text-secondary': colors.textSecondary,
         'clip-video': colors.clipVideo,
         'clip-audio': colors.clipAudio,
         ...trackColors,
@@ -26,6 +29,7 @@ export default {
       fontFamily: fonts.family,
       fontSize: {
         'ui-label': fonts.size.uiLabel,
+        'ui-caption': fonts.size.uiCaption,
         'ui-body': fonts.size.uiBody,
         'ui-heading': fonts.size.uiHeading,
       },


### PR DESCRIPTION
## Summary
- add CSS variables for accent, panel colors and text colors
- update Tailwind config to expose theme tokens
- unify button, input, slider styles and add tooltip component
- tweak panel header styling and clip hover/selected states
- show toast notifications for import/export actions

## Testing
- `yarn lint` *(fails: many prettier errors)*
- `yarn test`