### PR TITLE
Fix scrub handler and memoize library selectors

### DIFF
--- a/apps/web/src/features/library/MediaLibraryPanel.tsx
+++ b/apps/web/src/features/library/MediaLibraryPanel.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Button } from '../../components/ui/Button'
 import Panel from '../../components/Panel'
-import { useMediaStore, selectMediaArray, selectFolderArray } from '../../state/mediaStore'
+import { useMediaStore } from '../../state/mediaStore'
 import AssetCard from './AssetCard'
 import { extractVideoMetadata } from '../../lib/file/extractVideoMetadata'
 import { useUILayoutStore } from '../../state/uiLayoutStore'
@@ -30,8 +30,10 @@ async function pickFiles(): Promise<File[]> {
 }
 
 export default function MediaLibraryPanel() {
-  const assets = useMediaStore(selectMediaArray)
-  const folders = useMediaStore(selectFolderArray)
+  const assetsObj = useMediaStore((s) => s.assets)
+  const foldersObj = useMediaStore((s) => s.folders)
+  const assets = React.useMemo(() => Object.values(assetsObj), [assetsObj])
+  const folders = React.useMemo(() => Object.values(foldersObj), [foldersObj])
   const addAssets = useMediaStore((s) => s.addAssets)
   const addFolder = useMediaStore((s) => s.addFolder)
   const setShowLibrary = useUILayoutStore((s) => s.setShowLibrary)
@@ -71,7 +73,6 @@ export default function MediaLibraryPanel() {
     if (name) addFolder(name)
   }
 
-
   const assetsByFolder = React.useMemo(() => {
     const map: Record<string, any[]> = {}
     assets.forEach((a) => {
@@ -104,11 +105,7 @@ export default function MediaLibraryPanel() {
       <div className="mb-2">
         <Button onClick={handleImport}>Import Media</Button>
       </div>
-      <div
-        className="space-y-2"
-        onDragOver={(e) => e.preventDefault()}
-        onDrop={handleDrop}
-      >
+      <div className="space-y-2" onDragOver={(e) => e.preventDefault()} onDrop={handleDrop}>
         {renderFolder('root', 0)}
       </div>
     </Panel>

--- a/apps/web/src/features/timeline/TracksContainer.tsx
+++ b/apps/web/src/features/timeline/TracksContainer.tsx
@@ -34,6 +34,7 @@ export const TracksContainer: React.FC<TracksContainerProps> = React.memo(
     playing,
     scrollLeft,
     onBackgroundPointerDown,
+    onScrubStart,
     onScroll,
   }) => {
     const renderedTracks = React.useMemo(
@@ -64,10 +65,7 @@ export const TracksContainer: React.FC<TracksContainerProps> = React.memo(
           onPointerDown={onBackgroundPointerDown}
           onScroll={onScroll}
         >
-          <div
-            className="relative h-full flex flex-col"
-            style={{ width: duration * pixelsPerSecond }}
-          >
+          <div className="relative h-full flex flex-col" style={{ width: duration * pixelsPerSecond }}>
             {renderedTracks}
             {beats.map((b) => (
               <div


### PR DESCRIPTION
## Summary
- avoid undefined `onScrubStart` by passing it through `TracksContainer`
- use stable memoized arrays for library assets and folders

## Testing
- `yarn test`
- `yarn lint` *(fails: Unexpected any in worker files)*