### PR TITLE
Fix Vite alias for Radix Menubar

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
       'lucide-react': new URL('./src/stubs/lucide-react.tsx', import.meta.url).pathname,
       'yjs': new URL('./src/stubs/yjs.ts', import.meta.url).pathname,
       'y-protocols/awareness': new URL('./src/stubs/awareness.ts', import.meta.url).pathname,
+      '@radix-ui/react-menubar': new URL('./src/stubs/radix-menubar.tsx', import.meta.url).pathname,
     },
   },
   optimizeDeps: {


### PR DESCRIPTION
## Summary
- add alias for `@radix-ui/react-menubar` in the web app's Vite config

## Testing
- `yarn lint` *(fails: 1478 errors)*
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_683a5c9663b48328883ccf0f1254ab61