### PR TITLE
Fix spacing on 8px grid

### DIFF
--- a/apps/web/src/StoreTest.tsx
+++ b/apps/web/src/StoreTest.tsx
@@ -11,7 +11,7 @@ export function StoreTest() {
 
   return (
     <div className="p-4 bg-panel-bg-secondary rounded-lg">
-      <h2 className="text-ui-body font-ui-medium text-text-secondary mb-3">Store Test</h2>
+      <h2 className="text-ui-body font-ui-medium text-text-secondary mb-2">Store Test</h2>
       <pre className="text-xs bg-panel-bg p-2 rounded">
         {JSON.stringify(
           {

--- a/apps/web/src/features/export/ExportProgress.tsx
+++ b/apps/web/src/features/export/ExportProgress.tsx
@@ -6,7 +6,7 @@ export function ExportProgress() {
   if (!isExporting) return null
 
   return (
-    <div className="w-full space-y-1">
+    <div className="w-full space-y-2">
       <span className="block text-xs text-gray-400 font-ui-normal" role="status">
         Exporting…
       </span>

--- a/apps/web/src/features/import/BeatDetectionProgress.tsx
+++ b/apps/web/src/features/import/BeatDetectionProgress.tsx
@@ -12,7 +12,7 @@ export function BeatDetectionProgress() {
   const label = beatDetectionStage === 'extractAudio' ? 'Extracting audio…' : 'Detecting beats…'
 
   return (
-    <div className="w-full space-y-1">
+    <div className="w-full space-y-2">
       <span className="block text-xs text-gray-400 font-ui-normal" role="status">
         {label}
       </span>

--- a/apps/web/src/features/import/FileInfoCard.tsx
+++ b/apps/web/src/features/import/FileInfoCard.tsx
@@ -23,7 +23,7 @@ export default function FileInfoCard() {
   return (
     <div className="p-4 rounded-lg bg-panel-bg-secondary text-text-primary space-y-2">
       <h3 className="text-ui-body font-ui-medium text-accent">Imported File</h3>
-      <div className="text-ui-body font-ui-normal flex flex-col space-y-1">
+      <div className="text-ui-body font-ui-normal flex flex-col space-y-2">
         <div>
           <span className="text-gray-400">Name:</span> {fileInfo.fileName}
         </div>
@@ -41,7 +41,7 @@ export default function FileInfoCard() {
           </div>
         )}
         {fileInfo.videoCodec && (
-          <div className="flex items-center space-x-1">
+          <div className="flex items-center space-x-2">
             <span className="text-gray-400">Video:</span>
             <span>{fileInfo.videoCodec}</span>
             {fileInfo.videoSupported !== null && (
@@ -56,7 +56,7 @@ export default function FileInfoCard() {
           </div>
         )}
         {fileInfo.audioCodec && (
-          <div className="flex items-center space-x-1">
+          <div className="flex items-center space-x-2">
             <span className="text-gray-400">Audio:</span>
             <span>{fileInfo.audioCodec}</span>
             {fileInfo.audioSupported !== null && (

--- a/apps/web/src/features/shell/MainToolbar.tsx
+++ b/apps/web/src/features/shell/MainToolbar.tsx
@@ -26,7 +26,7 @@ export const MainToolbar: React.FC = () => {
   const handleSplit = React.useCallback(() => splitClipAt(currentTime), [splitClipAt, currentTime])
 
   return (
-    <div className="toolbar bg-panel-bg-secondary px-2 py-1 flex items-center space-x-1">
+    <div className="toolbar bg-panel-bg-secondary px-2 py-1 flex items-center space-x-2">
       <Button
         variant="secondary"
         className="toolbar-button"

--- a/apps/web/src/features/timeline/TimelineToolbar.tsx
+++ b/apps/web/src/features/timeline/TimelineToolbar.tsx
@@ -31,16 +31,16 @@ export const TimelineToolbar: React.FC<TimelineToolbarProps> = ({ zoom, onZoomCh
     <div className="flex items-center space-x-2">
       <PlayPauseButton />
       <ZoomSlider value={zoom} onChange={onZoomChange} />
-      <Button variant="secondary" className="px-2 py-1" onClick={handleSplit}>
+      <Button variant="secondary" className="toolbar-button" onClick={handleSplit}>
         <Scissors className="w-4 h-4" />
       </Button>
-      <Button variant="secondary" className="px-2 py-1" onClick={handleDelete}>
+      <Button variant="secondary" className="toolbar-button" onClick={handleDelete}>
         <Trash2 className="w-4 h-4" />
       </Button>
-      <Button variant="secondary" className="px-2 py-1" onClick={() => setSnapping(!snapping)}>
+      <Button variant="secondary" className="toolbar-button" onClick={() => setSnapping(!snapping)}>
         <Magnet className="w-4 h-4" />
       </Button>
-      <Button variant="secondary" className="px-2 py-1" onClick={() => setFollowPlayhead(!followPlayhead)}>
+      <Button variant="secondary" className="toolbar-button" onClick={() => setFollowPlayhead(!followPlayhead)}>
         <Crosshair className="w-4 h-4" />
       </Button>
     </div>

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -59,10 +59,10 @@ body {
   @apply text-text-primary rounded focus-visible:outline-none;
 }
 .menubar-content {
-  @apply bg-panel-bg-secondary text-text-primary;
+  @apply bg-panel-bg-secondary text-text-primary py-1;
 }
 .toolbar-button {
-  @apply p-1 rounded;
+  @apply px-2 py-1 rounded;
 }
 .toolbar-button:hover {
   @apply bg-accent/30;


### PR DESCRIPTION
## Summary
- widen icon spacing in MainToolbar
- standardize icon button padding and dropdown padding
- use toolbar-button utility in TimelineToolbar
- normalize layout spacing in info cards and progress components
- trim StoreTest header margin

## Testing
- `yarn lint` *(fails: 1378 errors)*
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_683fda1ad0248328a5095e87ba4f9b4e