### PR TITLE
Fix focus ring visuals

### DIFF
--- a/apps/web/src/components/Panel.tsx
+++ b/apps/web/src/components/Panel.tsx
@@ -13,7 +13,11 @@ export default function Panel({ title, onCollapse, children, className }: PanelP
       <div className="flex items-center justify-between px-2 py-2 bg-panel-bg-secondary border-b border-panel-bg">
         <span className="text-ui-body font-ui-semibold">{title}</span>
         {onCollapse && (
-          <button type="button" onClick={onCollapse} className="text-xs hover:text-accent">
+          <button
+            type="button"
+            onClick={onCollapse}
+            className="text-xs hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-panel-bg"
+          >
             &laquo;
           </button>
         )}

--- a/apps/web/src/components/ui/Button.tsx
+++ b/apps/web/src/components/ui/Button.tsx
@@ -17,7 +17,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(({ classN
   return (
     <Comp
       ref={ref}
-      className={`inline-flex items-center justify-center rounded px-4 py-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-40 ${variantClasses[variant]} ${className}`}
+      className={`inline-flex items-center justify-center rounded px-4 py-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-panel-bg disabled:pointer-events-none disabled:opacity-40 ${variantClasses[variant]} ${className}`}
       {...(props as any)}
     />
   )

--- a/apps/web/src/components/ui/Input.tsx
+++ b/apps/web/src/components/ui/Input.tsx
@@ -8,7 +8,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
   ({ className = '', ...props }, ref) => (
     <input
       ref={ref}
-      className={`h-8 rounded border border-panel-bg-secondary bg-panel-bg px-2 text-sm text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent disabled:opacity-40 ${className}`}
+      className={`h-8 rounded border border-panel-bg-secondary bg-panel-bg px-2 text-sm text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-panel-bg disabled:opacity-40 ${className}`}
       {...props}
     />
   ),

--- a/apps/web/src/features/import/MediaIngest.tsx
+++ b/apps/web/src/features/import/MediaIngest.tsx
@@ -137,7 +137,7 @@ export default function MediaIngest() {
     >
       <button
         onClick={openPicker}
-        className="px-4 py-2 bg-accent text-white rounded hover:bg-accent/90 disabled:opacity-50"
+        className="px-4 py-2 bg-accent text-white rounded hover:bg-accent/90 disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-panel-bg"
         disabled={loading}
       >
         {loading ? 'Importing...' : 'Import Media'}

--- a/apps/web/src/features/preview/PreviewPanel.tsx
+++ b/apps/web/src/features/preview/PreviewPanel.tsx
@@ -151,14 +151,26 @@ export const PreviewPanel: React.FC = React.memo(() => {
       <video ref={videoRef} className="w-full h-full object-contain" playsInline />
       {showControls && (
         <div className="absolute bottom-2 left-0 right-0 flex items-center justify-center gap-4 text-xs bg-black/60 px-2 py-1 fade-in show">
-          <button type="button" onClick={togglePlay} className="px-2">
+          <button
+            type="button"
+            onClick={togglePlay}
+            className="px-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-panel-bg"
+          >
             {playing ? '❚❚' : '▶'}
           </button>
           <span className="font-mono">{formatTimecode(currentTime)}</span>
-          <button type="button" onClick={toggleMute} className="px-2">
+          <button
+            type="button"
+            onClick={toggleMute}
+            className="px-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-panel-bg"
+          >
             {muted ? '🔇' : '🔊'}
           </button>
-          <button type="button" onClick={enterFullscreen} className="px-2">
+          <button
+            type="button"
+            onClick={enterFullscreen}
+            className="px-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-panel-bg"
+          >
             ⛶
           </button>
         </div>

--- a/apps/web/src/features/timeline/components/TrackRow.tsx
+++ b/apps/web/src/features/timeline/components/TrackRow.tsx
@@ -119,7 +119,9 @@ export const TrackRow: React.FC<TrackRowProps> = React.memo(({
           type="button"
           onClick={toggleLock}
           aria-label={track.locked ? 'Unlock track' : 'Lock track'}
-          className={track.locked ? 'opacity-50' : ''}
+          className={`${
+            track.locked ? 'opacity-50' : ''
+          } focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-panel-bg`}
         >
           <LockIcon className="w-4 h-4" />
         </button>
@@ -129,7 +131,9 @@ export const TrackRow: React.FC<TrackRowProps> = React.memo(({
           aria-label={
             track.muted ? (isAudio ? 'Unmute track' : 'Show track') : isAudio ? 'Mute track' : 'Hide track'
           }
-          className={track.muted ? 'opacity-50' : ''}
+          className={`${
+            track.muted ? 'opacity-50' : ''
+          } focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-panel-bg`}
         >
           <MuteIcon className="w-4 h-4" />
         </button>


### PR DESCRIPTION
## Summary
- add theme-colored ring offsets to Button and Input
- expose focus styling on panel collapse controls
- ensure preview panel controls and track row icons show accent ring
- show focus ring on import media button

## Testing
- `yarn lint` *(fails: eslint errors)*
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_683fe06bbd488328a980ffdb3e1f02d9