### PR TITLE
Fix tailwind border class

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -79,7 +79,7 @@ body {
   @apply text-text-secondary;
 }
 .menubar-content [role='separator'] {
-  @apply my-1 border-t border-text-secondary/20;
+  @apply my-1 border-t border-text-secondary border-opacity-20;
 }
 .toolbar-button {
   @apply px-2 py-1 rounded;


### PR DESCRIPTION
## Summary
- fix menubar separator border color by using `border-text-secondary` with opacity

## Testing
- `yarn lint` *(fails: 1397 problems)*
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_683fe5c88a9883288f9dfaec5c93c668