### PR TITLE
Hide empty Effects section

### DIFF
--- a/apps/web/src/features/inspector/InspectorPanel.tsx
+++ b/apps/web/src/features/inspector/InspectorPanel.tsx
@@ -92,10 +92,12 @@ export default function InspectorPanel() {
           <Switch checked={muted} onChange={(e) => setMuted(e.target.checked)} />
         </label>
       </section>
-      <section>
-        <h3 className="font-ui-medium text-accent mb-1">Effects</h3>
-        <div className="text-xs text-gray-400">No effects</div>
-      </section>
+      {clip.effects.length > 0 && (
+        <section>
+          <h3 className="font-ui-medium text-accent mb-1">Effects</h3>
+          <div className="text-xs text-gray-400">No effects</div>
+        </section>
+      )}
     </div>
   )
 }

--- a/apps/web/src/state/timelineStore.ts
+++ b/apps/web/src/state/timelineStore.ts
@@ -28,6 +28,8 @@ export interface Clip {
   volume: number
   /** mute audio */
   muted: boolean
+  /** clip effects pipeline */
+  effects: unknown[]
 }
 
 export interface Track {
@@ -194,6 +196,7 @@ export const useTimelineStore = create<TimelineState>((set, get) => ({
       rotation: 0,
       volume: 1,
       muted: false,
+      effects: [],
       ...clipInput,
       id,
       groupId: opts?.groupId,


### PR DESCRIPTION
## Summary
- add an `effects` field to clips
- default `effects` when creating clips
- hide the Effects panel in the inspector unless a clip has effects

## Testing
- `yarn lint` *(fails: no matching files)*
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_683fe54f30c48328b422a7c28faf06d5