### PR TITLE
Add fade animations to toast and share modal

### DIFF
--- a/apps/web/src/components/Toast.tsx
+++ b/apps/web/src/components/Toast.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 interface Toast {
   id: number
   message: string
+  visible: boolean
 }
 
 const ToastContext = React.createContext<(msg: string) => void>(() => {})
@@ -13,9 +14,12 @@ export const ToastProvider: React.FC<{ children: React.ReactNode }> = ({ childre
 
   const addToast = React.useCallback((message: string) => {
     const id = Date.now()
-    setToasts((t) => [...t, { id, message }])
+    setToasts((t) => [...t, { id, message, visible: true }])
     setTimeout(() => {
-      setToasts((t) => t.filter((toast) => toast.id !== id))
+      setToasts((t) => t.map((toast) => (toast.id === id ? { ...toast, visible: false } : toast)))
+      setTimeout(() => {
+        setToasts((t) => t.filter((toast) => toast.id !== id))
+      }, 150)
     }, 3000)
   }, [])
 
@@ -31,7 +35,10 @@ export const ToastProvider: React.FC<{ children: React.ReactNode }> = ({ childre
       {children}
         <div className="fixed bottom-4 left-1/2 -translate-x-1/2 space-y-2 z-50">
           {toasts.map((t) => (
-            <div key={t.id} className="bg-panel-bg-secondary text-text-primary px-4 py-2 rounded shadow">
+            <div
+              key={t.id}
+              className={`toast-message fade-in ${t.visible ? 'show' : ''} bg-panel-bg-secondary text-text-primary px-4 py-2 rounded shadow`}
+            >
               {t.message}
             </div>
           ))}

--- a/apps/web/src/features/collab/ShareDialog.tsx
+++ b/apps/web/src/features/collab/ShareDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { Button } from '../../components/ui/Button'
 import { Input } from '../../components/ui/Input'
 import { useCollabStore } from '../../state/collabStore'
@@ -12,10 +12,21 @@ export function ShareDialog({ onClose }: ShareDialogProps) {
   const createSession = useCollabStore((s) => s.createSession)
   const joinSession = useCollabStore((s) => s.joinSession)
   const [createdId, setCreatedId] = useState<string | null>(null)
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    const id = requestAnimationFrame(() => setVisible(true))
+    return () => cancelAnimationFrame(id)
+  }, [])
+
+  const handleClose = () => {
+    setVisible(false)
+    setTimeout(onClose, 150)
+  }
 
   return (
-    <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50">
-      <div className="bg-panel-bg-secondary rounded p-6 w-80 space-y-4">
+    <div className={`fixed inset-0 bg-black/60 flex items-center justify-center z-50 fade-in ${visible ? 'show' : ''}`}> 
+      <div className={`bg-panel-bg-secondary rounded p-6 w-80 space-y-4 fade-in ${visible ? 'show' : ''}`}>
         {createdId ? (
           <div>
             <p className="mb-2">Session ID:</p>
@@ -36,7 +47,7 @@ export function ShareDialog({ onClose }: ShareDialogProps) {
           </div>
         )}
         <div className="text-right">
-          <Button variant="secondary" onClick={onClose}>Close</Button>
+          <Button variant="secondary" onClick={handleClose}>Close</Button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- animate toast notifications with fade-in/out
- fade in share dialog and animate its closing

## Testing
- `yarn lint` *(fails: many unrelated lint errors)*
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_683fe7fab27483288569166081af618b