### PR TITLE
Improve accessibility for library and dialogs

### DIFF
--- a/apps/web/src/features/collab/ShareDialog.tsx
+++ b/apps/web/src/features/collab/ShareDialog.tsx
@@ -25,8 +25,15 @@ export function ShareDialog({ onClose }: ShareDialogProps) {
   }
 
   return (
-    <div className={`fixed inset-0 bg-black/60 flex items-center justify-center z-50 fade-in ${visible ? 'show' : ''}`}> 
-      <div className={`bg-panel-bg-secondary rounded p-6 w-80 space-y-4 fade-in ${visible ? 'show' : ''}`}>
+    <div
+      className={`fixed inset-0 bg-black/60 flex items-center justify-center z-50 fade-in ${visible ? 'show' : ''}`}
+    >
+      <div
+        className={`bg-panel-bg-secondary rounded p-6 w-80 space-y-4 fade-in ${visible ? 'show' : ''}`}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Collaboration Options"
+      >
         {createdId ? (
           <div>
             <p className="mb-2">Session ID:</p>
@@ -34,7 +41,9 @@ export function ShareDialog({ onClose }: ShareDialogProps) {
           </div>
         ) : (
           <div className="space-y-2">
-            <Button onClick={() => setCreatedId(createSession())}>Create Session</Button>
+            <Button autoFocus onClick={() => setCreatedId(createSession())}>
+              Create Session
+            </Button>
             <div className="flex gap-2 items-center">
               <Input
                 value={sessionIdInput}

--- a/apps/web/src/features/library/AssetCard.tsx
+++ b/apps/web/src/features/library/AssetCard.tsx
@@ -8,7 +8,7 @@ interface AssetCardProps {
 
 export function AssetCard({ asset }: AssetCardProps) {
   const handleDragStart = React.useCallback(
-    (e: React.DragEvent<HTMLDivElement>) => {
+    (e: React.DragEvent<HTMLButtonElement>) => {
       e.dataTransfer.setData('text/x-mediamix-asset', asset.id)
     },
     [asset.id],
@@ -20,11 +20,14 @@ export function AssetCard({ asset }: AssetCardProps) {
   )
 
   return (
-    <div
-      className={`w-20 box-border text-center text-xs select-none rounded cursor-pointer hover:bg-panel-bg-secondary ${isSelected ? 'border-2 border-accent' : 'border-2 border-transparent'}`}
+    <button
+      type="button"
+      className={`w-20 box-border text-center text-xs select-none rounded cursor-pointer hover:bg-panel-bg-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent ${isSelected ? 'border-2 border-accent' : 'border-2 border-transparent'}`}
       draggable
       onDragStart={handleDragStart}
-      onClick={() => useSelectionStore.getState().setSelection({ type: 'asset', id: asset.id })}
+      onClick={() =>
+        useSelectionStore.getState().setSelection({ type: 'asset', id: asset.id })
+      }
     >
       {isVideo ? (
         <img src={asset.thumbnail} alt="thumbnail" className="w-full h-12 object-cover rounded mb-1" />
@@ -34,7 +37,7 @@ export function AssetCard({ asset }: AssetCardProps) {
         </div>
       )}
       <div className="truncate">{asset.fileName}</div>
-    </div>
+    </button>
   )
 }
 

--- a/apps/web/src/features/timeline/TimelineToolbar.tsx
+++ b/apps/web/src/features/timeline/TimelineToolbar.tsx
@@ -37,10 +37,22 @@ export const TimelineToolbar: React.FC<TimelineToolbarProps> = ({ zoom, onZoomCh
       <Button variant="secondary" className="toolbar-button" onClick={handleDelete}>
         <Trash2 className="w-4 h-4" />
       </Button>
-      <Button variant="secondary" className="toolbar-button" onClick={() => setSnapping(!snapping)}>
+      <Button
+        variant="secondary"
+        className="toolbar-button"
+        onClick={() => setSnapping(!snapping)}
+        aria-pressed={snapping}
+        aria-label="Toggle snapping"
+      >
         <Magnet className="w-4 h-4" />
       </Button>
-      <Button variant="secondary" className="toolbar-button" onClick={() => setFollowPlayhead(!followPlayhead)}>
+      <Button
+        variant="secondary"
+        className="toolbar-button"
+        onClick={() => setFollowPlayhead(!followPlayhead)}
+        aria-pressed={followPlayhead}
+        aria-label="Toggle follow playhead"
+      >
         <Crosshair className="w-4 h-4" />
       </Button>
     </div>


### PR DESCRIPTION
## Summary
- make AssetCard a button element for keyboard focus
- add ARIA attributes to ShareDialog
- expose toggle state via `aria-pressed` on timeline snapping/follow buttons
- keep lint and test status

## Testing
- `yarn lint` *(fails: lots of prettier errors)*
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_683fe97776e48328b1b6a243713e6025